### PR TITLE
PO-987 - Passing Data Via Router

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/abstract/abstract-form-parent-base/abstract-form-parent-base.component.spec.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-form-parent-base/abstract-form-parent-base.component.spec.ts
@@ -80,7 +80,7 @@ describe('AbstractFormParentBaseComponent', () => {
 
     const routerSpy = spyOn(component['router'], 'navigate');
     component['routerNavigate']('test', true);
-    expect(routerSpy).toHaveBeenCalledWith(['test']);
+    expect(routerSpy).toHaveBeenCalledWith(['test'], {});
   });
 
   it('should test routerNavigate with event', () => {
@@ -94,6 +94,24 @@ describe('AbstractFormParentBaseComponent', () => {
 
     component['routerNavigate']('test', false, event);
     expect(routerSpy).toHaveBeenCalledWith(['test'], { relativeTo: component['activatedRoute'].parent });
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  it('should test routerNavigate with routeData', () => {
+    if (!component) {
+      fail('component returned null');
+      return;
+    }
+
+    const routerSpy = spyOn(component['router'], 'navigate');
+    const event = jasmine.createSpyObj('event', ['preventDefault']);
+    const routeData = { someData: 'test' };
+
+    component['routerNavigate']('test', false, event, routeData);
+    expect(routerSpy).toHaveBeenCalledWith(['test'], {
+      relativeTo: component['activatedRoute'].parent,
+      state: routeData,
+    });
     expect(event.preventDefault).toHaveBeenCalled();
   });
 

--- a/projects/opal-frontend-common/components/abstract/abstract-form-parent-base/abstract-form-parent-base.component.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-form-parent-base/abstract-form-parent-base.component.ts
@@ -24,20 +24,26 @@ export abstract class AbstractFormParentBaseComponent {
   }
 
   /**
-   * Navigates to the specified route using the Angular router.
+   * Navigates to a specified route using the Angular Router.
    *
-   * @param route - The route to navigate to.
+   * @param route - The target route to navigate to.
+   * @param nonRelative - A boolean indicating whether the navigation should be absolute (true)
+   *                      or relative to the current route (false). Defaults to false.
+   * @param event - (Optional) The event object, typically from a click event, to prevent its default behavior.
+   * @param routeData - (Optional) Additional data to pass to the target route's state.
    */
-  protected routerNavigate(route: string, nonRelative: boolean = false, event?: Event): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected routerNavigate(route: string, nonRelative: boolean = false, event?: Event, routeData?: any): void {
     if (event) {
       event.preventDefault();
     }
 
-    if (nonRelative) {
-      this.router.navigate([route]);
-    } else {
-      this.router.navigate([route], { relativeTo: this.activatedRoute.parent });
-    }
+    const navigationExtras = {
+      ...(nonRelative ? {} : { relativeTo: this.activatedRoute.parent }),
+      ...(routeData !== undefined ? { state: routeData } : {}),
+    };
+
+    this.router.navigate([route], navigationExtras);
   }
 
   /**

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",

--- a/projects/opal-frontend-common/services/utils-service/utils.service.spec.ts
+++ b/projects/opal-frontend-common/services/utils-service/utils.service.spec.ts
@@ -180,4 +180,24 @@ describe('UtilsService', () => {
       expect(error).toEqual('Clipboard error');
     }
   });
+
+  it('should filter out null and undefined values from an object', () => {
+    const input = {
+      a: 'value',
+      b: null,
+      c: undefined,
+      d: 0,
+      e: '',
+      f: false,
+    };
+
+    const result = service.filterNullOrUndefined(input);
+
+    expect(result).toEqual({
+      a: 'value',
+      d: 0,
+      e: '',
+      f: false,
+    });
+  });
 });

--- a/projects/opal-frontend-common/services/utils-service/utils.service.spec.ts
+++ b/projects/opal-frontend-common/services/utils-service/utils.service.spec.ts
@@ -181,7 +181,7 @@ describe('UtilsService', () => {
     }
   });
 
-  it('should filter out null and undefined values from an object', () => {
+  it('should recursively filter out null and undefined values from an object', () => {
     const input = {
       a: 'value',
       b: null,
@@ -189,6 +189,18 @@ describe('UtilsService', () => {
       d: 0,
       e: '',
       f: false,
+      g: {
+        g1: null,
+        g2: 'nested',
+        g3: {
+          g3a: undefined,
+          g3b: 'deep',
+        },
+      },
+      h: {},
+      i: {
+        i1: null,
+      },
     };
 
     const result = service.filterNullOrUndefined(input);
@@ -198,6 +210,14 @@ describe('UtilsService', () => {
       d: 0,
       e: '',
       f: false,
+      g: {
+        g2: 'nested',
+        g3: {
+          g3b: 'deep',
+        },
+      },
+      h: {},
+      i: {},
     });
   });
 });

--- a/projects/opal-frontend-common/services/utils-service/utils.service.ts
+++ b/projects/opal-frontend-common/services/utils-service/utils.service.ts
@@ -103,4 +103,22 @@ export class UtilsService {
   public copyToClipboard(value: string): Promise<void> {
     return navigator.clipboard.writeText(value);
   }
+
+  /**
+   * Filters out properties from an object where the value is either `null` or `undefined`.
+   *
+   * @param obj - The object to filter. It should be a record with string keys and values of any type.
+   * @returns A new object containing only the properties with non-null and non-undefined values.
+   *
+   * @example
+   * ```typescript
+   * const input = { a: 1, b: null, c: undefined, d: 'hello' };
+   * const result = filterNullOrUndefined(input);
+   * console.log(result); // Output: { a: 1, d: 'hello' }
+   * ```
+   */
+  public filterNullOrUndefined(obj: Record<string, unknown>): Record<string, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return Object.fromEntries(Object.entries(obj).filter(([_, value]) => value !== null && value !== undefined));
+  }
 }

--- a/projects/opal-frontend-common/services/utils-service/utils.service.ts
+++ b/projects/opal-frontend-common/services/utils-service/utils.service.ts
@@ -105,20 +105,35 @@ export class UtilsService {
   }
 
   /**
-   * Filters out properties from an object where the value is either `null` or `undefined`.
+   * Recursively filters out properties from an object where the value is `null` or `undefined`.
    *
-   * @param obj - The object to filter. It should be a record with string keys and values of any type.
-   * @returns A new object containing only the properties with non-null and non-undefined values.
+   * @param obj - The object to filter. Can include nested objects.
+   * @returns A new object with only non-null and non-undefined values.
    *
    * @example
-   * ```typescript
-   * const input = { a: 1, b: null, c: undefined, d: 'hello' };
+   * ```ts
+   * const input = {
+   *   a: 1,
+   *   b: null,
+   *   c: undefined,
+   *   d: 'hello',
+   *   e: { x: null, y: 2 },
+   *   f: { z: undefined },
+   * };
    * const result = filterNullOrUndefined(input);
-   * console.log(result); // Output: { a: 1, d: 'hello' }
+   * console.log(result); // Output: { a: 1, d: 'hello', e: { y: 2 } }
    * ```
    */
   public filterNullOrUndefined(obj: Record<string, unknown>): Record<string, unknown> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return Object.fromEntries(Object.entries(obj).filter(([_, value]) => value !== null && value !== undefined));
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([_, value]) => value !== null && value !== undefined)
+        .map(([key, value]) => {
+          if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+            return [key, this.filterNullOrUndefined(value as Record<string, unknown>)];
+          }
+          return [key, value];
+        }),
+    );
   }
 }

--- a/projects/opal-frontend-common/services/utils-service/utils.service.ts
+++ b/projects/opal-frontend-common/services/utils-service/utils.service.ts
@@ -127,6 +127,7 @@ export class UtilsService {
   public filterNullOrUndefined(obj: Record<string, unknown>): Record<string, unknown> {
     return Object.fromEntries(
       Object.entries(obj)
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         .filter(([_, value]) => value !== null && value !== undefined)
         .map(([key, value]) => {
           if (typeof value === 'object' && !Array.isArray(value) && value !== null) {


### PR DESCRIPTION
### Jira link
[PO-987](https://tools.hmcts.net/jira/browse/PO-987)

### Change description
- As part of PO-987, we want to introduce a way of passing data to resolvers via the Angular Router 
- This change refactors the routerNavigate method in AbstractFormParentBaseComponent to conditionally include state only when routeData is explicitly provided
- This prevents unnecessary state: undefined properties from being added to navigation extras, ensuring cleaner and more predictable routing behaviour
This approach supports scenarios where dynamic data needs to be passed at navigation time, such as passing form input into a resolver without relying on shared stores or services

### Testing done
- Unit tests passing as expected
- Working with OPAL Frontend as expected

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
