### PR TITLE
Further changes for PO-987

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/constants/moj-sortable-table-header-sort-icons.constant.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/constants/moj-sortable-table-header-sort-icons.constant.ts
@@ -1,0 +1,6 @@
+// Extracted from @ministryofjustice/frontend v5.1.2 sortable-table.mjs
+export const MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS = {
+  ascending: 'M6.5625 15.5L11 6.63125L15.4375 15.5H6.5625Z',
+  descending: 'M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z',
+  none: ['M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z', 'M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z'],
+};

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.spec.ts
@@ -1,0 +1,72 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MojSortableTableHeaderSortIconDirective } from './moj-sortable-table-header-sort-icon.directive';
+import { MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS } from './constants/moj-sortable-table-header-sort-icons.constant';
+
+@Component({
+  template: ` <svg [opalLibMojSortableTableHeaderSortIcon]="sortDirection"></svg> `,
+  standalone: true,
+  imports: [MojSortableTableHeaderSortIconDirective],
+})
+class TestHostComponent {
+  sortDirection: 'ascending' | 'descending' | 'none' = 'none';
+}
+
+describe('MojSortableTableHeaderSortIconDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let component: TestHostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should render descending icon path when sortDirection is ascending', () => {
+    component.sortDirection = 'ascending';
+    fixture.detectChanges();
+
+    const paths = fixture.nativeElement.querySelectorAll('path');
+    expect(paths.length).toBe(1);
+    expect(paths[0].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.descending);
+  });
+
+  it('should render ascending icon path when sortDirection is descending', () => {
+    component.sortDirection = 'descending';
+    fixture.detectChanges();
+
+    const paths = fixture.nativeElement.querySelectorAll('path');
+    expect(paths.length).toBe(1);
+    expect(paths[0].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.ascending);
+  });
+
+  it('should render both neutral icon paths when sortDirection is none', () => {
+    component.sortDirection = 'none';
+    fixture.detectChanges();
+
+    const paths = fixture.nativeElement.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+    expect(paths[0].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.none[0]);
+    expect(paths[1].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.none[1]);
+  });
+
+  it('should clear previous paths when sortDirection changes', () => {
+    component.sortDirection = 'ascending';
+    fixture.detectChanges();
+
+    // At this point, one path (descending icon) is rendered
+    expect(fixture.nativeElement.querySelectorAll('path').length).toBe(1);
+
+    // Change direction to 'none', which should render two paths
+    component.sortDirection = 'none';
+    fixture.detectChanges();
+
+    const paths = fixture.nativeElement.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+    expect(paths[0].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.none[0]);
+    expect(paths[1].getAttribute('d')).toBe(MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS.none[1]);
+  });
+});

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.ts
@@ -9,8 +9,8 @@ export class MojSortableTableHeaderSortIconDirective implements OnChanges {
   @Input('opalLibMojSortableTableHeaderSortIcon') sortDirection: 'ascending' | 'descending' | 'none' = 'none';
 
   constructor(
-    private el: ElementRef<SVGSVGElement>,
-    private renderer: Renderer2,
+    private readonly el: ElementRef<SVGSVGElement>,
+    private readonly renderer: Renderer2,
   ) {}
 
   /**

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/directive/moj-sortable-table-header-sort-icon.directive.ts
@@ -1,0 +1,54 @@
+import { Directive, OnChanges, Input, ElementRef, Renderer2 } from '@angular/core';
+import { MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS } from './constants/moj-sortable-table-header-sort-icons.constant';
+
+@Directive({
+  selector: '[opalLibMojSortableTableHeaderSortIcon]',
+  standalone: true,
+})
+export class MojSortableTableHeaderSortIconDirective implements OnChanges {
+  @Input('opalLibMojSortableTableHeaderSortIcon') sortDirection: 'ascending' | 'descending' | 'none' = 'none';
+
+  constructor(
+    private el: ElementRef<SVGSVGElement>,
+    private renderer: Renderer2,
+  ) {}
+
+  /**
+   * Returns the SVG path(s) for the sort icon based on the specified direction.
+   *
+   * @param dir - The sort direction, which can be 'ascending', 'descending', or 'none'.
+   * @returns An array of SVG path strings corresponding to the given sort direction.
+   */
+  private getPathsForDirection(dir: 'ascending' | 'descending' | 'none'): string[] {
+    const icons = MOJ_SORTABLE_TABLE_HEADER_SORT_ICONS;
+    switch (dir) {
+      case 'ascending':
+        return [icons.descending];
+      case 'descending':
+        return [icons.ascending];
+      default:
+        return icons.none;
+    }
+  }
+
+  public ngOnChanges(): void {
+    const svg = this.el.nativeElement;
+    this.renderer.setAttribute(svg, 'xmlns', 'http://www.w3.org/2000/svg');
+    this.renderer.setAttribute(svg, 'fill', 'none');
+
+    // Clear existing <path> children
+    while (svg.firstChild) {
+      svg.removeChild(svg.firstChild);
+    }
+
+    // Append new <path> elements based on sortDirection
+    const paths = this.getPathsForDirection(this.sortDirection);
+    paths.forEach((pathD) => {
+      const path = this.renderer.createElement('path', 'svg');
+      this.renderer.setAttribute(path, 'd', pathD);
+      this.renderer.setAttribute(path, 'fill', 'currentColor');
+
+      svg.appendChild(path);
+    });
+  }
+}

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.html
@@ -1,3 +1,12 @@
-<button [attr.data-index]="dataIndex" (click)="toggleSort()" type="button">
+<button type="button" (click)="toggleSort()" [attr.aria-sort]="sortDirection" [attr.data-index]="dataIndex">
   <ng-content></ng-content>
+  <svg
+    [opalLibMojSortableTableHeaderSortIcon]="sortDirection"
+    width="22"
+    height="22"
+    focusable="false"
+    aria-hidden="true"
+    role="img"
+    vviewBox="0 0 22 22"
+  ></svg>
 </button>

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.html
@@ -1,4 +1,4 @@
-<button type="button" (click)="toggleSort()" [attr.aria-sort]="sortDirection" [attr.data-index]="dataIndex">
+<button type="button" (click)="toggleSort()" [attr.data-index]="dataIndex">
   <ng-content></ng-content>
   <svg
     [opalLibMojSortableTableHeaderSortIcon]="sortDirection"

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table-header/moj-sortable-table-header.component.ts
@@ -1,10 +1,11 @@
 import { Component, HostBinding, ChangeDetectionStrategy, Output, EventEmitter, Input } from '@angular/core';
+import { MojSortableTableHeaderSortIconDirective } from './directive/moj-sortable-table-header-sort-icon.directive';
 
 @Component({
   selector: 'opal-lib-moj-sortable-table-header, [opal-lib-moj-sortable-table-header]',
-  imports: [],
   templateUrl: './moj-sortable-table-header.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MojSortableTableHeaderSortIconDirective],
 })
 export class MojSortableTableHeaderComponent {
   @Input() columnKey!: string;

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.spec.ts
@@ -29,18 +29,4 @@ describe('MojSortableTableComponent', () => {
     fixture.detectChanges();
     expect(component.tableClasses).toBe('test-class');
   });
-
-  it('should call initAll on date picker library', waitForAsync(() => {
-    const initAllSpy = jasmine.createSpy('initAll');
-    spyOn(component, 'configureSortableTable').and.callFake(() => {
-      return Promise.resolve({
-        initAll: initAllSpy,
-      }).then((library) => {
-        library.initAll();
-        expect(initAllSpy).toHaveBeenCalled();
-      });
-    });
-
-    component.configureSortableTable();
-  }));
 });

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MojSortableTableComponent } from './moj-sortable-table.component';
 

--- a/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sortable-table/moj-sortable-table.component.ts
@@ -1,5 +1,4 @@
-import { afterNextRender, ChangeDetectionStrategy, Component, Input } from '@angular/core';
-import { addGdsBodyClass } from '@hmcts/opal-frontend-common/components/govuk/helpers';
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 
 @Component({
   selector: 'opal-lib-moj-sortable-table',
@@ -9,21 +8,4 @@ import { addGdsBodyClass } from '@hmcts/opal-frontend-common/components/govuk/he
 })
 export class MojSortableTableComponent {
   @Input({ required: false }) public tableClasses!: string;
-
-  constructor() {
-    afterNextRender(() => {
-      // Only trigger the render of the component in the browser
-      this.configureSortableTable();
-    });
-  }
-
-  /**
-   * Configures the sortable functionality using the moj library.
-   */
-  public configureSortableTable(): void {
-    import('@ministryofjustice/frontend/moj/all').then((sortableTable) => {
-      addGdsBodyClass();
-      sortableTable.initAll();
-    });
-  }
 }

--- a/projects/opal-frontend-common/directives/capitalisation/capitalisation.directive.ts
+++ b/projects/opal-frontend-common/directives/capitalisation/capitalisation.directive.ts
@@ -9,9 +9,9 @@ import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service
 export class CapitalisationDirective implements OnInit, OnDestroy {
   @Input('opalLibCapitaliseAllCharacters') control!: AbstractControl;
 
-  private destroy$ = new Subject<void>();
+  private readonly destroy$ = new Subject<void>();
 
-  constructor(private utilsService: UtilsService) {}
+  constructor(private readonly utilsService: UtilsService) {}
 
   ngOnInit(): void {
     if (!this.control) return;

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,9 +1997,9 @@
   integrity sha512-3GQDdX2Xmy1smEyR/U4FUTGEaL7fbGT8kU5tyfRz1CLZ+bM1smhKMth0NvVQNAh+qfYEtUBGCAWrARe4iMq5iQ==
 
 "@ngrx/signals@^19.0.1":
-  version "19.1.0"
-  resolved "https://registry.yarnpkg.com/@ngrx/signals/-/signals-19.1.0.tgz#1ff62c5c019f08e1a37692e077f46832570871ba"
-  integrity sha512-v8sbb+Iox9kdIaKbFgt4Z1W+NxzIU4+g+6qQU6/c27UmtQXv0s1zUKKofPRK0qwkaZzNWkxNToxyoE285ukqcQ==
+  version "19.2.0"
+  resolved "https://registry.yarnpkg.com/@ngrx/signals/-/signals-19.2.0.tgz#4bb05cac94df0da9b9e7caf97fd00cd4899bc2e5"
+  integrity sha512-7NMFZE5HU/bryU15vCA2aHDYa77Pb7nCit4UOcsk9WkCSWMwtyQ4/9eR6wSGdeX5xxDcFQy0IiZJ8wxYCxA5Eg==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
### Jira link
[PO-987](https://tools.hmcts.net/jira/browse/PO-987)

### Change description
A new version of MoJ Frontend introduced a change which had a knock on impact to the MoJ Sortable Table Component. We added the JS which they introduced but this has a further impact on our Abstract Sorting/Pagination strategy. Therefore:
- This PR reverts the JS inclusion on the MoJ Sortable Table component
- Introduces a directive to put the MoJ Sortable Table Heading Sort Icons in based on the sort direction

### Testing done
- Working expected with the frontend 
- Unit tests passing as expected

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
