### PR TITLE
PO-593 - Abstract Tab Data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.spec.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+import { AbstractTabData } from './abstract-tab-data';
+import { Router, ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+class TestTabData extends AbstractTabData {}
+
+describe('AbstractTabData', () => {
+  let service: TestTabData;
+  let router: jasmine.SpyObj<Router>;
+  let activatedRoute: jasmine.SpyObj<ActivatedRoute>;
+
+  beforeEach(() => {
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    activatedRoute = jasmine.createSpyObj('ActivatedRoute', [], {
+      parent: {},
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        TestTabData,
+      ],
+    });
+
+    service = TestBed.inject(TestTabData);
+  });
+
+  it('should format count with cap correctly', () => {
+    expect(service.formatCountWithCap(10, 99)).toBe('10');
+    expect(service.formatCountWithCap(100, 99)).toBe('99+');
+  });
+
+  it('should navigate and set activeTab on handleTabSwitch', () => {
+    service.handleTabSwitch('example-tab');
+    expect(service.activeTab).toBe('example-tab');
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      relativeTo: activatedRoute.parent,
+      fragment: 'example-tab',
+    });
+  });
+
+  it('should return transformed data from createTabDataStream when tab === initialTab', (done) => {
+    const initialData = { value: 1 };
+    const initialTab = 'tab1';
+    const fragment$ = of(initialTab);
+    const result = service.createTabDataStream(
+      initialData,
+      initialTab,
+      fragment$,
+      () => ({}),
+      () => of({ value: 2 }),
+      (data) => data.value.toString(),
+    );
+    result.subscribe((res) => {
+      expect(res).toBe('1');
+      done();
+    });
+  });
+
+  it('should fetch and transform data from createTabDataStream when tab !== initialTab', (done) => {
+    const initialData = { value: 1 };
+    const initialTab = 'tab1';
+    const fragment$ = of('tab2');
+    const result = service.createTabDataStream(
+      initialData,
+      initialTab,
+      fragment$,
+      () => ({}),
+      () => of({ value: 2 }),
+      (data) => data.value.toString(),
+    );
+    result.subscribe((res) => {
+      expect(res).toBe('2');
+      done();
+    });
+  });
+
+  it('should return formatted count from createCountStream when tab === initialTab', (done) => {
+    const result = service.createCountStream(
+      'tab1',
+      5,
+      of('tab1'),
+      () => ({}),
+      () => of({ count: 99 }),
+      (data) => data.count,
+      (count) => `${count}+`,
+    );
+    result.subscribe((res) => {
+      expect(res).toBe('5+');
+      done();
+    });
+  });
+
+  it('should fetch and format count from createCountStream when tab !== initialTab', (done) => {
+    const result = service.createCountStream(
+      'tab1',
+      5,
+      of('tab2'),
+      () => ({}),
+      () => of({ count: 150 }),
+      (data) => data.count,
+      (count) => (count > 99 ? '99+' : `${count}`),
+    );
+    result.subscribe((res) => {
+      expect(res).toBe('99+');
+      done();
+    });
+  });
+
+  it('should use the default formatFn when none is provided', (done) => {
+    const fragment$ = of('tab1');
+    const initialTab = 'tab1';
+    const initialCount = 7;
+
+    const result = service.createCountStream(
+      initialTab,
+      initialCount,
+      fragment$,
+      () => ({}),
+      () => of({ count: 123 }),
+      (data) => data.count,
+    );
+
+    result.subscribe((res) => {
+      expect(res).toBe('7');
+      done();
+    });
+  });
+});

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.ts
@@ -1,0 +1,137 @@
+import { inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Observable, of, switchMap, map, shareReplay } from 'rxjs';
+
+export abstract class AbstractTabData {
+  private readonly router = inject(Router);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  public activeTab!: string;
+
+  /**
+   * Creates an observable stream that conditionally fetches and transforms data based on the current tab.
+   *
+   * If the current tab matches the `initialTab`, the stream emits the provided `initialValue`.
+   * Otherwise, it fetches data using the `fetchData` function with parameters obtained from `getParams`,
+   * transforms the result using the `transform` function, and shares the result among subscribers.
+   *
+   * @template T The type of data returned by the fetchData observable.
+   * @template U The type of the value emitted by the resulting observable.
+   * @param initialTab - The tab identifier that triggers emission of the initial value.
+   * @param fragment$ - An observable emitting the current tab identifier.
+   * @param initialValue - The value to emit when the current tab matches `initialTab`.
+   * @param getParams - A function that returns parameters for data fetching based on the tab.
+   * @param fetchData - A function that fetches data as an observable, given the parameters.
+   * @param transform - A function to transform the fetched data before emission.
+   * @returns An observable emitting either the initial value or the transformed fetched data, depending on the current tab.
+   */
+  private createConditionalStream<T, U>(
+    initialTab: string,
+    fragment$: Observable<string>,
+    initialValue: U,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getParams: (tab?: string) => any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchData: (params: any) => Observable<T>,
+    transform: (data: T) => U,
+  ): Observable<U> {
+    return fragment$.pipe(
+      switchMap((tab) =>
+        tab === initialTab ? of(initialValue) : fetchData(getParams(tab)).pipe(map(transform), shareReplay(1)),
+      ),
+    );
+  }
+
+  /**
+   * Creates an observable data stream for a tab, transforming the fetched data as needed.
+   *
+   * @template T The type of the data fetched.
+   * @template R The type of the transformed data.
+   * @param initialData The initial data to use before fetching.
+   * @param initialTab The initial tab identifier.
+   * @param fragment$ An observable emitting the current tab fragment.
+   * @param getParams A function that returns fetch parameters based on the tab.
+   * @param fetchData A function that fetches data given the parameters.
+   * @param transform A function to transform the fetched data.
+   * @returns An observable emitting the transformed data for the current tab.
+   */
+  public createTabDataStream<T, R>(
+    initialData: T,
+    initialTab: string,
+    fragment$: Observable<string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getParams: (tab?: string) => any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchData: (params: any) => Observable<T>,
+    transform: (data: T) => R,
+  ): Observable<R> {
+    return this.createConditionalStream<T, R>(
+      initialTab,
+      fragment$,
+      transform(initialData),
+      getParams,
+      fetchData,
+      transform,
+    );
+  }
+
+  /**
+   * Creates an observable stream that emits a formatted count string based on the current tab and fragment.
+   *
+   * @template T - The type of the data returned by the fetchCount observable.
+   * @param initialTab - The initial tab identifier.
+   * @param initialCount - The initial count value to display before fetching.
+   * @param fragment$ - An observable emitting the current fragment or tab identifier.
+   * @param getParams - A function that returns the parameters required for fetching the count.
+   * @param fetchCount - A function that takes the parameters and returns an observable emitting the count data.
+   * @param extractCount - A function that extracts the numeric count from the fetched data.
+   * @param formatFn - (Optional) A function to format the count as a string. Defaults to a simple string conversion.
+   * @returns An observable that emits the formatted count string whenever the fragment or parameters change.
+   */
+  public createCountStream<T>(
+    initialTab: string,
+    initialCount: number,
+    fragment$: Observable<string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getParams: () => any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    fetchCount: (params: any) => Observable<T>,
+    extractCount: (data: T) => number,
+    formatFn: (count: number) => string = (c) => `${c}`,
+  ): Observable<string> {
+    return this.createConditionalStream<T, string>(
+      initialTab,
+      fragment$,
+      formatFn(initialCount),
+      () => getParams(),
+      fetchCount,
+      (data) => formatFn(extractCount(data)),
+    );
+  }
+
+  /**
+   * Handles the tab switch by updating the active tab and triggering a router fragment update.
+   *
+   * @param fragment - The identifier of the tab to activate.
+   */
+  public handleTabSwitch(fragment: string): void {
+    this.activeTab = fragment;
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute.parent,
+      fragment,
+    });
+  }
+
+  /**
+   * Formats a count value, capping it at a specified maximum.
+   *
+   * If the count exceeds the cap, returns a string in the format "{cap}+".
+   * Otherwise, returns the count as a string.
+   *
+   * @param count - The number to format.
+   * @param cap - The maximum value to display before capping.
+   * @returns A string representing the count, capped if necessary.
+   */
+  public formatCountWithCap(count: number, cap: number): string {
+    return count > cap ? `${cap}+` : `${count}`;
+  }
+}

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/ng-package.json
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/package.json
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": false,
+  "module": "../../../../dist/opal-frontend-common/fesm2022/hmcts-opal-frontend-common-components-abstract-abstract-tab-data.mjs",
+  "typings": "../../../../dist/opal-frontend-common/components/abstract/abstract-tab-data/index.d.ts"
+}

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/public-api.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/public-api.ts
@@ -1,0 +1,1 @@
+export * from './abstract-tab-data';

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/readme.md
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/readme.md
@@ -1,0 +1,130 @@
+# Abstract Tab Data
+
+The `AbstractTabData` class provides a reusable Angular base class for managing tab-based observable data streams in your components. It is designed for components that need to update their data views when a user switches tabs, without duplicating stream logic.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Methods](#methods)
+- [Testing](#testing)
+- [Contributing](#contributing)
+
+## Installation
+
+To use the `AbstractTabData` class, extend it in your Angular component or service:
+
+```ts
+import { AbstractTabData } from '@hmcts/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data';
+```
+
+## Usage
+
+Extend this class in a component where you need to switch views based on the current tab and update data accordingly.
+
+### Example:
+
+```ts
+@Component({ ... })
+export class MyTabComponent extends AbstractTabData {
+  tabData$: Observable<MyViewModel[]>;
+
+  ngOnInit(): void {
+    this.tabData$ = this.createTabDataStream(
+      this.initialData,
+      'default-tab',
+      this.activatedRoute.fragment,
+      (tab) => this.buildParamsForTab(tab),
+      (params) => this.myService.getData(params),
+      (res) => this.transformData(res)
+    );
+  }
+
+  onTabChange(tab: string): void {
+    this.handleTabSwitch(tab);
+  }
+}
+```
+
+## Methods
+
+### `createTabDataStream`
+
+Creates an observable data stream that emits transformed data based on the active tab.
+
+```ts
+createTabDataStream<T, R>(
+  initialData: T,
+  initialTab: string,
+  fragment$: Observable<string>,
+  getParams: (tab?: string) => any,
+  fetchData: (params: any) => Observable<T>,
+  transform: (data: T) => R
+): Observable<R>
+```
+
+If the current tab matches `initialTab`, the transformed `initialData` is emitted. Otherwise, new data is fetched and transformed.
+
+---
+
+### `createCountStream`
+
+Emits a formatted count string based on the current tab and fragment.
+
+```ts
+createCountStream<T>(
+  initialTab: string,
+  initialCount: number,
+  fragment$: Observable<string>,
+  getParams: () => any,
+  fetchCount: (params: any) => Observable<T>,
+  extractCount: (data: T) => number,
+  formatFn?: (count: number) => string
+): Observable<string>
+```
+
+Defaults to using the format function `(c) => \`\${c}\``. Useful for badge counts and tab indicators.
+
+---
+
+### `handleTabSwitch`
+
+Sets `activeTab` and triggers a navigation update with the new fragment.
+
+```ts
+handleTabSwitch(fragment: string): void
+```
+
+---
+
+### `formatCountWithCap`
+
+Returns a formatted count string, capping it at a given value.
+
+```ts
+formatCountWithCap(count: number, cap: number): string
+```
+
+Example:
+```ts
+formatCountWithCap(112, 99); // => "99+"
+```
+
+## Testing
+
+You can create unit tests by extending `AbstractTabData` in a test class and mocking its dependencies.
+
+### Example Test
+
+```ts
+class MockComponent extends AbstractTabData {}
+const instance = new MockComponent();
+
+expect(instance.formatCountWithCap(120, 99)).toBe('99+');
+```
+
+For more advanced tests, mock `ActivatedRoute` and `Router` via Angular TestBed and use `TestComponent` wrappers.
+
+## Contributing
+
+If you want to improve the shared tab-handling logic or suggest new utility patterns, feel free to submit a PR. Keep the logic generic and framework-agnostic so it can be reused across all tab-based components in the platform.

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",
@@ -55,6 +55,9 @@
     },
     "./components/abstract/abstract-sortable-table-pagination": {
       "import": "./fesm2022/hmcts-opal-frontend-common-components-abstract-abstract-sortable-table-pagination.mjs"
+    },
+    "./components/abstract/abstract-tab-data": {
+      "import": "./fesm2022/hmcts-opal-frontend-common-components-abstract-abstract-tab-data.mjs"
     },
     "./components/abstract/interfaces": {
       "import": "./fesm2022/hmcts-opal-frontend-common-components-abstract-interfaces.mjs"


### PR DESCRIPTION
### Jira link
[PO-593](https://tools.hmcts.net/jira/browse/PO-593)

### Change description
- As part of this ticket, we want to introduce a standard way of retrieving the data when using tabs. This works by allowing initial data to be rendered and then when the tab switches this calls off the API.
- It has been made as generic and dumb as possible to allow use across different parts of the application

### Testing done
- Building, and unit tests running as expected
- Works locally with opal-frontend

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
