### PR TITLE
PO-593

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/abstract-tab-data.ts
@@ -1,44 +1,67 @@
 import { inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable, of, switchMap, map, shareReplay } from 'rxjs';
+import { Observable, switchMap, map, shareReplay, distinctUntilChanged, filter, startWith, takeUntil, tap } from 'rxjs';
 
 export abstract class AbstractTabData {
   private readonly router = inject(Router);
-  private readonly activatedRoute = inject(ActivatedRoute);
+  public readonly activatedRoute = inject(ActivatedRoute);
   public activeTab!: string;
 
   /**
-   * Creates an observable stream that conditionally fetches and transforms data based on the current tab.
+   * Creates an observable stream that fetches and transforms data based on the current tab.
    *
-   * If the current tab matches the `initialTab`, the stream emits the provided `initialValue`.
-   * Otherwise, it fetches data using the `fetchData` function with parameters obtained from `getParams`,
+   * It fetches data using the `fetchData` function with parameters obtained from `getParams`,
    * transforms the result using the `transform` function, and shares the result among subscribers.
    *
    * @template T The type of data returned by the fetchData observable.
    * @template U The type of the value emitted by the resulting observable.
-   * @param initialTab - The tab identifier that triggers emission of the initial value.
    * @param fragment$ - An observable emitting the current tab identifier.
-   * @param initialValue - The value to emit when the current tab matches `initialTab`.
    * @param getParams - A function that returns parameters for data fetching based on the tab.
    * @param fetchData - A function that fetches data as an observable, given the parameters.
    * @param transform - A function to transform the fetched data before emission.
-   * @returns An observable emitting either the initial value or the transformed fetched data, depending on the current tab.
+   * @returns An observable emitting the transformed fetched data, depending on the current tab.
    */
   private createConditionalStream<T, U>(
-    initialTab: string,
     fragment$: Observable<string>,
-    initialValue: U,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getParams: (tab?: string) => any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fetchData: (params: any) => Observable<T>,
     transform: (data: T) => U,
   ): Observable<U> {
-    return fragment$.pipe(
-      switchMap((tab) =>
-        tab === initialTab ? of(initialValue) : fetchData(getParams(tab)).pipe(map(transform), shareReplay(1)),
-      ),
+    return fragment$.pipe(switchMap((tab) => fetchData(getParams(tab)).pipe(map(transform), shareReplay(1))));
+  }
+
+  /**
+   * Returns an observable stream of the current URL fragment, starting with the initial fragment or a default tab.
+   *
+   * This method listens to changes in the route fragment and emits the fragment value as a string.
+   * It starts with the current fragment (or the provided default tab if none exists), filters out falsy values,
+   * ensures only distinct values are emitted, and completes when the provided `destroy$` observable emits.
+   *
+   * @param defaultTab - The default tab to use if no fragment is present in the route snapshot.
+   * @param destroy$ - An observable that signals when to complete the fragment stream.
+   * @returns An observable emitting the current fragment string, updating on changes, and completing on destroy.
+   */
+  protected getFragmentStream(defaultTab: string, destroy$: Observable<void>): Observable<string> {
+    return this.activatedRoute.fragment.pipe(
+      startWith(this.activatedRoute.snapshot.fragment ?? defaultTab),
+      filter((frag): frag is string => !!frag),
+      map((tab) => tab!),
+      distinctUntilChanged(),
+      takeUntil(destroy$),
     );
+  }
+
+  /**
+   * Wraps a fragment stream and executes the provided callback on each tab change.
+   *
+   * @param fragment$ - The fragment observable stream.
+   * @param clearFn - A function to execute when the tab changes.
+   * @returns The fragment stream with a side-effect to run `clearFn` on each emission.
+   */
+  protected clearCacheOnTabChange(fragment$: Observable<string>, clearFn: () => void): Observable<string> {
+    return fragment$.pipe(tap(() => clearFn()));
   }
 
   /**
@@ -46,8 +69,6 @@ export abstract class AbstractTabData {
    *
    * @template T The type of the data fetched.
    * @template R The type of the transformed data.
-   * @param initialData The initial data to use before fetching.
-   * @param initialTab The initial tab identifier.
    * @param fragment$ An observable emitting the current tab fragment.
    * @param getParams A function that returns fetch parameters based on the tab.
    * @param fetchData A function that fetches data given the parameters.
@@ -55,8 +76,6 @@ export abstract class AbstractTabData {
    * @returns An observable emitting the transformed data for the current tab.
    */
   public createTabDataStream<T, R>(
-    initialData: T,
-    initialTab: string,
     fragment$: Observable<string>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     getParams: (tab?: string) => any,
@@ -64,22 +83,13 @@ export abstract class AbstractTabData {
     fetchData: (params: any) => Observable<T>,
     transform: (data: T) => R,
   ): Observable<R> {
-    return this.createConditionalStream<T, R>(
-      initialTab,
-      fragment$,
-      transform(initialData),
-      getParams,
-      fetchData,
-      transform,
-    );
+    return this.createConditionalStream<T, R>(fragment$, getParams, fetchData, transform);
   }
 
   /**
    * Creates an observable stream that emits a formatted count string based on the current tab and fragment.
    *
    * @template T - The type of the data returned by the fetchCount observable.
-   * @param initialTab - The initial tab identifier.
-   * @param initialCount - The initial count value to display before fetching.
    * @param fragment$ - An observable emitting the current fragment or tab identifier.
    * @param getParams - A function that returns the parameters required for fetching the count.
    * @param fetchCount - A function that takes the parameters and returns an observable emitting the count data.
@@ -88,23 +98,21 @@ export abstract class AbstractTabData {
    * @returns An observable that emits the formatted count string whenever the fragment or parameters change.
    */
   public createCountStream<T>(
-    initialTab: string,
-    initialCount: number,
     fragment$: Observable<string>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getParams: () => any,
+    getParams: (tab?: string) => any,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fetchCount: (params: any) => Observable<T>,
     extractCount: (data: T) => number,
     formatFn: (count: number) => string = (c) => `${c}`,
   ): Observable<string> {
-    return this.createConditionalStream<T, string>(
-      initialTab,
-      fragment$,
-      formatFn(initialCount),
-      () => getParams(),
-      fetchCount,
-      (data) => formatFn(extractCount(data)),
+    return fragment$.pipe(
+      switchMap((tab) =>
+        fetchCount(getParams(tab)).pipe(
+          map((data) => formatFn(extractCount(data))),
+          shareReplay(1),
+        ),
+      ),
     );
   }
 

--- a/projects/opal-frontend-common/components/abstract/abstract-tab-data/readme.md
+++ b/projects/opal-frontend-common/components/abstract/abstract-tab-data/readme.md
@@ -30,10 +30,13 @@ export class MyTabComponent extends AbstractTabData {
   tabData$: Observable<MyViewModel[]>;
 
   ngOnInit(): void {
+    const fragment$ = this.clearCacheOnTabChange(
+      this.getFragmentStream('default-tab', this.destroy$),
+      () => this.myService.clearMyCache()
+    );
+
     this.tabData$ = this.createTabDataStream(
-      this.initialData,
-      'default-tab',
-      this.activatedRoute.fragment,
+      fragment$,
       (tab) => this.buildParamsForTab(tab),
       (params) => this.myService.getData(params),
       (res) => this.transformData(res)
@@ -54,8 +57,6 @@ Creates an observable data stream that emits transformed data based on the activ
 
 ```ts
 createTabDataStream<T, R>(
-  initialData: T,
-  initialTab: string,
   fragment$: Observable<string>,
   getParams: (tab?: string) => any,
   fetchData: (params: any) => Observable<T>,
@@ -63,20 +64,14 @@ createTabDataStream<T, R>(
 ): Observable<R>
 ```
 
-If the current tab matches `initialTab`, the transformed `initialData` is emitted. Otherwise, new data is fetched and transformed.
-
----
-
 ### `createCountStream`
 
 Emits a formatted count string based on the current tab and fragment.
 
 ```ts
 createCountStream<T>(
-  initialTab: string,
-  initialCount: number,
   fragment$: Observable<string>,
-  getParams: () => any,
+  getParams: (tab?: string) => any,
   fetchCount: (params: any) => Observable<T>,
   extractCount: (data: T) => number,
   formatFn?: (count: number) => string
@@ -84,8 +79,23 @@ createCountStream<T>(
 ```
 
 Defaults to using the format function `(c) => \`\${c}\``. Useful for badge counts and tab indicators.
+### `getFragmentStream`
+
+Returns a stream of the current route fragment, starting with the current snapshot or a fallback.
+
+```ts
+getFragmentStream(defaultTab: string, destroy$: Observable<void>): Observable<string>
+```
 
 ---
+
+### `clearCacheOnTabChange`
+
+Wraps a fragment stream and executes a side-effect when the tab changes.
+
+```ts
+clearCacheOnTabChange(fragment$: Observable<string>, clearFn: () => void): Observable<string>
+```
 
 ### `handleTabSwitch`
 

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",

--- a/projects/opal-frontend-common/stores/global/global.store.spec.ts
+++ b/projects/opal-frontend-common/stores/global/global.store.spec.ts
@@ -10,7 +10,10 @@ import {
   SESSION_TOKEN_EXPIRY_MOCK,
   SESSION_USER_STATE_MOCK,
 } from '@hmcts/opal-frontend-common/services/session-service/mocks';
-import { TRANSFER_STATE_LAUNCH_DARKLY_CONFIG_MOCK } from '@hmcts/opal-frontend-common/services/transfer-state-service/mocks';
+import {
+  TRANSFER_STATE_APP_INSIGHTS_CONFIG_MOCK,
+  TRANSFER_STATE_LAUNCH_DARKLY_CONFIG_MOCK,
+} from '@hmcts/opal-frontend-common/services/transfer-state-service/mocks';
 import { LAUNCH_DARKLY_CHANGE_FLAGS_MOCK } from '@hmcts/opal-frontend-common/services/launch-darkly-service/mocks';
 
 describe('GlobalStore', () => {
@@ -62,6 +65,12 @@ describe('GlobalStore', () => {
     const config = TRANSFER_STATE_LAUNCH_DARKLY_CONFIG_MOCK;
     store.setLaunchDarklyConfig(config);
     expect(store.launchDarklyConfig()).toEqual(config);
+  });
+
+  it('should update App Insights config', () => {
+    const config = TRANSFER_STATE_APP_INSIGHTS_CONFIG_MOCK;
+    store.setAppInsightsConfig(config);
+    expect(store.appInsightsConfig()).toEqual(config);
   });
 
   it('should update token expiry', () => {


### PR DESCRIPTION
### Jira link
[PO-593](https://tools.hmcts.net/jira/browse/PO-593)

### Change description
Refactored the AbstractTabData class to simplify tab-based data handling across components:
	•	Removed reliance on initialTab and initialData in createTabDataStream and createCountStream
	•	Introduced getFragmentStream() to standardise reactive tab fragment streams
	•	Introduced clearCacheOnTabChange() to handle per-tab cache invalidation generically
	•	Updated all consuming components to use the new utilities
	•	Converted tab resolvers to act as preloaders only — components now rely on service-level caching
	•	Improved internal test coverage and updated the README with current usage guidance

These changes standardise and simplify tab implementation, making it more maintainable and consistent across the app.

### Testing done
	•	✅ Full unit test coverage achieved on AbstractTabData
	•	✅ Components using setupTabDataStream() and setupRejectedCountStream() verified with updated logic
	•	✅ Resolvers updated and confirmed to preload cache without returning data
	•	✅ All consuming components tested to confirm tab switching still drives correct backend calls
	•	✅ Manual validation of tab navigation, cache clearing, and reactive UI updates
	•	✅ README updated to reflect the new APIs and usage examples

For frontend validation, we confirmed that tab fragments still update the correct stream, and resolved data is no longer required.

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
