### PR TITLE
PO-1844

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/govuk-tab-list-item.component.html
+++ b/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/govuk-tab-list-item.component.html
@@ -1,3 +1,1 @@
-<li class="govuk-tabs__list-item" [id]="tabsId + _tabsListItemId">
-  <a class="govuk-tabs__tab" [href]="tabListItemHref"> {{ tabListItemName }} </a>
-</li>
+<a class="govuk-tabs__tab" [href]="tabListItemHref"> {{ tabListItemName }} </a>

--- a/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/govuk-tab-list-item.component.ts
+++ b/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/govuk-tab-list-item.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, inject } from '@angular/core';
 import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 
 @Component({
-  selector: 'opal-lib-govuk-tab-list-item',
+  selector: 'opal-lib-govuk-tab-list-item, [opal-lib-govuk-tab-list-item]',
   imports: [],
   templateUrl: './govuk-tab-list-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -18,4 +18,7 @@ export class GovukTabListItemComponent {
 
   @Input({ required: true }) public tabListItemHref!: string;
   @Input({ required: true }) public tabListItemName!: string;
+
+  @HostBinding('class') hostClass = 'govuk-tabs__list-item';
+  @HostBinding('id') hostId = `${this.tabsId}_${this._tabsListItemId}`;
 }

--- a/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/readme.md
+++ b/projects/opal-frontend-common/components/govuk/govuk-tabs/govuk-tab-list-item/readme.md
@@ -25,22 +25,37 @@ import { GovukTabListItemComponent } from '@components/govuk/govuk-tab-list-item
 You can use the tab list item component in your template as follows:
 
 ```html
-<opal-lib-govuk-tab-list-item [tabTitle]="'Tab 1'"></opal-lib-govuk-tab-list-item>
+<li
+  opal-lib-govuk-tab-list-item
+  tabsId="example-tabs"
+  tabsListItemId="first"
+  tabListItemHref="#first-tab"
+  tabListItemName="First tab">
+</li>
 ```
 
 ### Example in HTML:
 
 ```html
-<li class="govuk-tabs__list-item">
-  <a class="govuk-tabs__tab" href="#tab-1">{{ tabTitle }}</a>
-</li>
+<ul class="govuk-tabs__list">
+  <li
+    opal-lib-govuk-tab-list-item
+    tabsId="example-tabs"
+    tabsListItemId="first"
+    tabListItemHref="#first-tab"
+    tabListItemName="First tab">
+  </li>
+</ul>
 ```
 
 ## Inputs
 
-| Input      | Type     | Description                                     |
-| ---------- | -------- | ----------------------------------------------- |
-| `tabTitle` | `string` | The title of the tab displayed in the tab list. |
+| Input               | Type     | Description                                                                |
+|--------------------|----------|----------------------------------------------------------------------------|
+| `tabsId`           | `string` | The unique ID for the tab set; used to generate the list item `id`.        |
+| `tabsListItemId`   | `string` | The ID of the tab item (automatically capitalised for ID generation).      |
+| `tabListItemHref`  | `string` | The `href` for the tab link.                                               |
+| `tabListItemName`  | `string` | The visible text label of the tab link.                                    |
 
 ## Outputs
 

--- a/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.html
@@ -1,10 +1,8 @@
-<li class="moj-primary-navigation__item" [class.last-item]="isLastItem" [id]="primaryNavigationItemId">
-  <a
-    href=""
-    class="moj-primary-navigation__link cursor-pointer"
-    [attr.aria-current]="primaryNavigationItemFragment === activeItemFragment ? 'page' : null"
-    (click)="handleItemClick($event, primaryNavigationItemFragment)"
-    (keyup.enter)="handleItemClick($event, primaryNavigationItemFragment)"
-    >{{ primaryNavigationItemText }}</a
-  >
-</li>
+<a
+  href=""
+  class="moj-primary-navigation__link cursor-pointer"
+  [attr.aria-current]="primaryNavigationItemFragment === activeItemFragment ? 'page' : null"
+  (click)="handleItemClick($event, primaryNavigationItemFragment)"
+  (keyup.enter)="handleItemClick($event, primaryNavigationItemFragment)"
+  >{{ primaryNavigationItemText }}</a
+>

--- a/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.spec.ts
@@ -37,9 +37,7 @@ describe('MojPrimaryNavigationItemComponent', () => {
   });
 
   it('should be an active link', () => {
-    const element = fixture.nativeElement
-      .querySelector('.moj-primary-navigation__link')
-      .getAttribute('aria-current');
+    const element = fixture.nativeElement.querySelector('.moj-primary-navigation__link').getAttribute('aria-current');
 
     expect(element).toBe('page');
   });

--- a/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.spec.ts
@@ -31,19 +31,14 @@ describe('MojPrimaryNavigationItemComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have an id', () => {
-    const element = fixture.nativeElement.querySelector('#example');
-    expect(element).toBeTruthy();
-  });
-
   it('should have item text', () => {
-    const element = fixture.nativeElement.querySelector('#example .moj-primary-navigation__link');
+    const element = fixture.nativeElement.querySelector('.moj-primary-navigation__link');
     expect(element.innerText).toBe(component.primaryNavigationItemText);
   });
 
   it('should be an active link', () => {
     const element = fixture.nativeElement
-      .querySelector('#example .moj-primary-navigation__link')
+      .querySelector('.moj-primary-navigation__link')
       .getAttribute('aria-current');
 
     expect(element).toBe('page');
@@ -54,7 +49,7 @@ describe('MojPrimaryNavigationItemComponent', () => {
     const cdr = fixture.debugElement.injector.get<ChangeDetectorRef>(ChangeDetectorRef);
     cdr.detectChanges();
 
-    const element = fixture.nativeElement.querySelector('#example .moj-primary-navigation__link');
+    const element = fixture.nativeElement.querySelector('.moj-primary-navigation__link');
 
     expect(element).not.toBe('page');
   });

--- a/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.ts
+++ b/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/moj-primary-navigation-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
@@ -17,6 +17,10 @@ export class MojPrimaryNavigationItemComponent {
   @Input({ required: true }) public primaryNavigationItemText!: string;
   @Input({ required: true }) public activeItemFragment!: string;
   @Input({ required: false }) public isLastItem: boolean = false;
+
+  @HostBinding('class') hostClass = 'moj-primary-navigation__item';
+  @HostBinding('id') hostId = `${this.primaryNavigationItemId}`;
+  @HostBinding('class.last-item') hostLastItem = this.isLastItem;
 
   /**
    * Handles the click event of a sub-navigation item.

--- a/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/readme.md
+++ b/projects/opal-frontend-common/components/moj/moj-primary-navigation/moj-primary-navigation-item/readme.md
@@ -25,23 +25,38 @@ import { MojPrimaryNavigationItemComponent } from '@components/moj/moj-primary-n
 You can use the primary navigation item component in your template as follows:
 
 ```html
-<opal-lib-moj-primary-navigation-item [label]="'Home'" [link]="'/home'"></opal-lib-moj-primary-navigation-item>
+<li
+  opal-lib-moj-primary-navigation-item
+  primaryNavigationItemId="home-link"
+  primaryNavigationItemFragment="home"
+  [activeItemFragment]="activeFragment"
+  primaryNavigationItemText="Home">
+</li>
 ```
 
 ### Example in HTML:
 
 ```html
-<li class="moj-primary-navigation__item">
-  <a class="moj-primary-navigation__link" href="{{ link }}">{{ label }}</a>
-</li>
+<ul class="moj-primary-navigation">
+  <li
+    opal-lib-moj-primary-navigation-item
+    primaryNavigationItemId="home-link"
+    primaryNavigationItemFragment="home"
+    [activeItemFragment]="activeFragment"
+    primaryNavigationItemText="Home">
+  </li>
+</ul>
 ```
 
 ## Inputs
 
-| Input   | Type     | Description                                       |
-| ------- | -------- | ------------------------------------------------- |
-| `label` | `string` | The label text displayed for the navigation item. |
-| `link`  | `string` | The URL or route the navigation item links to.    |
+| Input                      | Type      | Description                                                                 |
+|----------------------------|-----------|-----------------------------------------------------------------------------|
+| `primaryNavigationItemId` | `string`  | The ID applied to the `<li>` element for accessibility or testing purposes.|
+| `primaryNavigationItemFragment` | `string`  | The fragment identifier this item navigates to.                           |
+| `primaryNavigationItemText` | `string` | The text displayed for the navigation link.                                |
+| `activeItemFragment`      | `string`  | The current active fragment to compare against for aria-current.           |
+| `isLastItem`              | `boolean` | Whether this is the last item in the list (adds `last-item` class).        |
 
 ## Outputs
 

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.html
@@ -1,13 +1,11 @@
-<li class="moj-sub-navigation__item" [id]="subNavItemId">
-  <a
-    class="moj-sub-navigation__link cursor-pointer"
-    [attr.aria-current]="subNavItemFragment === activeSubNavItemFragment ? 'page' : ''"
-    (click)="handleItemClick($event, subNavItemFragment)"
-    (keyup.enter)="handleItemClick($event, subNavItemFragment)"
-    role="link"
-    tabindex="0"
-  >
-    {{ subNavItemText }}
-    <ng-content select="[badge]"></ng-content>
-  </a>
-</li>
+<a
+  class="moj-sub-navigation__link cursor-pointer"
+  [attr.aria-current]="subNavItemFragment === activeSubNavItemFragment ? 'page' : ''"
+  (click)="handleItemClick($event, subNavItemFragment)"
+  (keyup.enter)="handleItemClick($event, subNavItemFragment)"
+  role="link"
+  tabindex="0"
+>
+  {{ subNavItemText }}
+  <ng-content select="[badge]"></ng-content>
+</a>

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.spec.ts
@@ -31,20 +31,13 @@ describe('MojSubNavigationItemComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should have an id', () => {
-    const element = fixture.nativeElement.querySelector('#example');
-    expect(element).toBeTruthy();
-  });
-
   it('should have item text', () => {
-    const element = fixture.nativeElement.querySelector('#example .moj-sub-navigation__link');
+    const element = fixture.nativeElement.querySelector('.moj-sub-navigation__link');
     expect(element.innerText).toBe(component.subNavItemText);
   });
 
   it('should be an active link', () => {
-    const element = fixture.nativeElement
-      .querySelector('#example .moj-sub-navigation__link')
-      .getAttribute('aria-current');
+    const element = fixture.nativeElement.querySelector('.moj-sub-navigation__link').getAttribute('aria-current');
 
     expect(element).toBe('page');
   });
@@ -54,7 +47,7 @@ describe('MojSubNavigationItemComponent', () => {
     const cdr = fixture.debugElement.injector.get<ChangeDetectorRef>(ChangeDetectorRef);
     cdr.detectChanges();
 
-    const element = fixture.nativeElement.querySelector('#example .moj-sub-navigation__link');
+    const element = fixture.nativeElement.querySelector('.moj-sub-navigation__link');
 
     expect(element).not.toBe('page');
   });

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, Input, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, inject } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
 @Component({
-  selector: 'opal-lib-moj-sub-navigation-item',
+  selector: 'opal-lib-moj-sub-navigation-item, [opal-lib-moj-sub-navigation-item]',
   imports: [],
   templateUrl: './moj-sub-navigation-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -15,6 +15,9 @@ export class MojSubNavigationItemComponent {
   @Input({ required: true }) public subNavItemFragment!: string;
   @Input({ required: true }) public subNavItemText!: string;
   @Input({ required: true }) public activeSubNavItemFragment!: string;
+
+  @HostBinding('class') hostClass = 'moj-sub-navigation__item';
+  @HostBinding('id') hostId = this.subNavItemId;
 
   /**
    * Handles the click event of a sub-navigation item.

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/readme.md
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/readme.md
@@ -25,23 +25,30 @@ import { MojSubNavigationItemComponent } from '@components/moj/moj-sub-navigatio
 You can use the sub-navigation item component in your template as follows:
 
 ```html
-<opal-lib-moj-sub-navigation-item [label]="'Settings'" [link]="'/settings'"></opal-lib-moj-sub-navigation-item>
+<li opal-lib-moj-sub-navigation-item subNavItemText="Settings" [subNavItemFragment]="'settings'" [activeSubNavItemFragment]="activeTab"></li>
 ```
 
 ### Example in HTML:
 
 ```html
-<li class="moj-sub-navigation__item">
-  <a class="moj-sub-navigation__link" href="{{ link }}">{{ label }}</a>
-</li>
+<ul class="moj-sub-navigation">
+  <li opal-lib-moj-sub-navigation-item
+      subNavItemId="settings-tab"
+      [subNavItemFragment]="'settings'"
+      [activeSubNavItemFragment]="activeTab"
+      subNavItemText="Settings">
+  </li>
+</ul>
 ```
 
 ## Inputs
 
-| Input   | Type     | Description                                 |
-| ------- | -------- | ------------------------------------------- |
-| `label` | `string` | The text displayed for the navigation item. |
-| `link`  | `string` | The URL or route the item links to.         |
+| Input                      | Type     | Description                                                                 |
+|----------------------------|----------|-----------------------------------------------------------------------------|
+| `subNavItemText`           | `string` | The text displayed for the navigation link.                                |
+| `subNavItemFragment`       | `string` | The fragment identifier used to match active tab state.                    |
+| `activeSubNavItemFragment` | `string` | The currently active tab's fragment to compare against.                    |
+| `subNavItemId`             | `string` | The ID applied to the `<li>` element for accessibility or testing purposes.|
 
 ## Outputs
 

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",


### PR DESCRIPTION
### Jira link
[PO-1844](https://tools.hmcts.net/jira/browse/PO-1844)

### Change description
This PR addresses an accessibility violation raised by Axe Core regarding invalid markup within a `<ul>`. Only `<li>` elements are valid direct children of `<ul>`, but previously we used a custom element `<opal-lib-moj-sub-navigation-item>`, which violated HTML semantics.

- Updated the component selector
- Applied `class="moj-sub-navigation__item"` and `id="{{subNavItemId}}"` via `@HostBinding` on the `<li>` host element.
- Removed the inner `<li>` from the component template to avoid invalid nested structure
- Updated unit tests to reflect the new DOM structure and prevent null selector errors.
- Updated `README.md` to reflect new usage pattern with `<li opal-lib-moj-sub-navigation-item>` and correct input bindings.

### Testing done
- Tested locally with OPAL Frontend and working as expected
- AxeCore issues addresses
- Unit tests updated 

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
