### PR TITLE
fix(sub-navigation): add href to anchor for correct styling and test for presence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.html
@@ -1,10 +1,10 @@
 <a
-  class="moj-sub-navigation__link cursor-pointer"
+  class="moj-sub-navigation__link"
   [attr.aria-current]="subNavItemFragment === activeSubNavItemFragment ? 'page' : ''"
   (click)="handleItemClick($event, subNavItemFragment)"
   (keyup.enter)="handleItemClick($event, subNavItemFragment)"
-  role="link"
   tabindex="0"
+  href="#"
 >
   {{ subNavItemText }}
   <ng-content select="[badge]"></ng-content>

--- a/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.spec.ts
+++ b/projects/opal-frontend-common/components/moj/moj-sub-navigation/moj-sub-navigation-item/moj-sub-navigation-item.component.spec.ts
@@ -63,4 +63,9 @@ describe('MojSubNavigationItemComponent', () => {
       fragment: component.subNavItemFragment,
     });
   });
+
+  it('should include href attribute', () => {
+    const element = fixture.nativeElement.querySelector('.moj-sub-navigation__link');
+    expect(element.getAttribute('href')).toBe('#');
+  });
 });

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0",


### PR DESCRIPTION
### Jira link
- N/A

### Change description
- Added href="#" to the moj-sub-navigation__link anchor tag in the Common UI library to ensure GOV.UK styles apply correctly, resolving an issue where inactive sub-navigation links were incorrectly underlined.
- Also added a unit test to assert the presence of the href attribute to prevent regressions.

### Testing done
- Verified the visual fix manually in the browser: inactive sub-navigation items now render without underlines as per GOV.UK standards.
- Added a unit test to confirm that the href="#" attribute is applied to the anchor element.
- Confirmed that navigation continues to be handled by handleItemClick with event.preventDefault() to avoid page jumps.
- Ran full test suite to ensure no regressions were introduced.

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
