### PR TITLE
Updates library version and improves styling imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0 || ^20.0.0",

--- a/projects/opal-frontend-common/styles/styles.scss
+++ b/projects/opal-frontend-common/styles/styles.scss
@@ -1,7 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
+
+/* ==========================================================================
+   Library Dependencies
+   ==========================================================================
+   These imports include external styles used across the application.
+*/
 @import 'govuk-frontend/dist/govuk/all.scss';
-@import './custom/_custom-section_break.scss';
+@import '@ministryofjustice/frontend/moj/all.scss';
+@import 'accessible-autocomplete/dist/accessible-autocomplete.min.css';
 @import 'home-office-kit/sass/_loadingSpinner.scss';
+
+/* ==========================================================================
+   Custom Component Styles
+   ==========================================================================
+   Custom Component Styles authored within the OPAL Frontend Common UI Library.
+*/
+@import './custom/_custom-section_break.scss';
 @import './custom/custom-scrollable-panes';
 
 html,


### PR DESCRIPTION
### Jira link
- N/A

### Change description
- Increments package version from 0.0.27 to 0.0.28 for both main and project-specific packages to reflect updates.

- Enhances styling imports by including external dependencies such as MOJ frontend styles and accessible autocomplete CSS, improving consistency and accessibility.

- Reorganizes SCSS imports for better readability and maintainability.

### Testing done
- Working with OPAL Frontend

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
