### PR TITLE
PO-2075

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/components/abstract/abstract-form-base/abstract-form-base.component.ts
+++ b/projects/opal-frontend-common/components/abstract/abstract-form-base/abstract-form-base.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output, inject } from '@angular/core';
-import { FormArray, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { FormArray, FormControl, FormGroup, ValidatorFn } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { IAbstractFormBaseFieldError } from './interfaces/abstract-form-base-field-error.interface';

--- a/projects/opal-frontend-common/components/abstract/abstract-form-base/readme.md
+++ b/projects/opal-frontend-common/components/abstract/abstract-form-base/readme.md
@@ -28,7 +28,7 @@ This component is designed to be extended by form components to provide consiste
 ### Example Usage:
 
 ```typescript
-import { Component, OnInit, OnDestroy} from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { AbstractFormBaseComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-form-base/abstract-form-base.component';
 
@@ -73,21 +73,23 @@ The component provides several public properties for form management:
 
 ### Protected Methods
 
-| Method                              | Parameters                                                 | Description                                   |
-| ----------------------------------- | ---------------------------------------------------------- | --------------------------------------------- |
-| `createFormControl()`               | `validators: ValidatorFn[], initialValue?: string \| null` | Creates a form control with validators        |
-| `handleErrorMessages()`             | None                                                       | Processes and sets form error messages        |
-| `hasUnsavedChanges()`               | None                                                       | Checks if form has unsaved changes            |
-| `setInputValue()`                   | `value: string, controlPath: string`                       | Sets value for a specific form control        |
-| `handleDateInputFormErrors()`       | None                                                       | Handles date field error processing           |
-| `setInitialErrorMessages()`         | None                                                       | Initializes error message objects             |
-| `rePopulateForm()`                  | `state: any`                                               | Repopulates form with provided state          |
-| `createControl()`                   | `controlName: string, validators: ValidatorFn[]`           | Adds a new control to the form                |
-| `updateControl()`                   | `controlName: string, validators: ValidatorFn[]`           | Updates validators for existing control       |
-| `removeControl()`                   | `controlName: string`                                      | Removes a control from the form               |
-| `removeControlErrors()`             | `controlName: string`                                      | Removes error messages for a specific control |
-| `clearAllErrorMessages()`           | None                                                       | Clears all error messages                     |
-
+| Method                            | Parameters                                                 | Description                                                                                     |
+| --------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `createFormControl()`             | `validators: ValidatorFn[], initialValue?: string \| null` | Creates a form control with validators                                                          |
+| `handleErrorMessages()`           | None                                                       | Processes and sets form error messages                                                          |
+| `hasUnsavedChanges()`             | None                                                       | Checks if form has unsaved changes                                                              |
+| `setInputValue()`                 | `value: string, controlPath: string`                       | Sets value for a specific form control                                                          |
+| `handleDateInputFormErrors()`     | None                                                       | Handles date field error processing                                                             |
+| `setInitialErrorMessages()`       | None                                                       | Initializes error message objects                                                               |
+| `rePopulateForm()`                | `state: any`                                               | Repopulates form with provided state                                                            |
+| `createControl()`                 | `controlName: string, validators: ValidatorFn[]`           | Adds a new control to the form                                                                  |
+| `updateControl()`                 | `controlName: string, validators: ValidatorFn[]`           | Updates validators for existing control                                                         |
+| `removeControl()`                 | `controlName: string`                                      | Removes a control from the form                                                                 |
+| `removeControlErrors()`           | `controlName: string`                                      | Removes error messages for a specific control                                                   |
+| `clearAllErrorMessages()`         | None                                                       | Clears all error messages                                                                       |
+| `clearFormGroupControls()`        | `group: FormGroup`                                         | Removes all controls from the specified FormGroup, useful for nested group resets               |
+| `addFreshControlsFromTemplates()` | `group: FormGroup, templates: Record<string, FormControl>` | Adds fresh FormControls (copying validator config) from a template map into the given FormGroup |
+| `replaceFormGroupControls()`      | `group: FormGroup, templates: Record<string, FormControl>` | Clears the given FormGroup then adds fresh controls from the provided templates                 |
 
 ### Example Template Usage:
 

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "license": "MIT",
   "peerDependencies": {
     "@angular/common": "^18.2.0 || ^19.0.0 || ^20.0.0",


### PR DESCRIPTION
### Jira link
[PO-2075](https://tools.hmcts.net/jira/browse/PO-2075)

### Change description
Introduces three protected methods to streamline operations on FormGroups: clearing controls, adding fresh controls from templates, and replacing controls with fresh instances. Ensures state isolation and prevents stale data leaks.

Updates corresponding unit tests to validate the behavior of the new methods.

Bumps package versions to 0.0.34.

### Testing done
- Unit tests passing
- Works well with OPAL Frontend 

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
