### PR TITLE
fix(moj-filter): remove conflicting aria-label to improve accessibility

### DIFF
--- a/projects/opal-frontend-common/components/moj/moj-filter/moj-filter.component.html
+++ b/projects/opal-frontend-common/components/moj/moj-filter/moj-filter.component.html
@@ -7,7 +7,6 @@
       type="button"
       class="govuk-button govuk-button--secondary moj-filter-layout__toggle-button"
       aria-controls="filter"
-      aria-label="Toggle filter panel"
       [attr.aria-expanded]="showFilter"
       (click)="toggleFilter()"
     >


### PR DESCRIPTION
### Jira link
N/A

### Change description
- Address final code smell which SonarQube shows in Overall Code
- I've fixed the accessibility issue by removing the aria-label="Toggle filter panel" attribute. Now the button's accessible name will be the visible text content ("Hide filter" or "Show filter"), which is much clearer and more descriptive for screen reader users.

### Testing done
- Unit tests passing as expected

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
