### PR TITLE
chore(ci): migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm_build.yml
+++ b/.github/workflows/npm_build.yml
@@ -13,6 +13,9 @@ jobs:
     name: Build, Test, and Analyse
     if: github.event_name != 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -64,13 +67,21 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           always-auth: true
 
+      - name: Ensure npm version (Trusted Publishing)
+        run: |
+          npm --version
+          npm i -g npm@11.5.1
+          npm --version
+
+
       - name: Install dependencies (Release)
         run: yarn install --frozen-lockfile
 
       - name: Build library (Release)
         run: yarn build
 
-      - name: Publish version
-        run: cd dist/opal-frontend-common && yarn publish --new-version ${{ steps.release.outputs.version }} --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_api_token }}
+      - name: Publish version (OIDC via npm)
+        working-directory: dist/opal-frontend-common
+        run: |
+          npm version "${{ steps.release.outputs.version }}" --no-git-tag-version
+          npm publish --access public


### PR DESCRIPTION
### Jira link
- N/A

### Change description
### What
Migrates npm publishing for the common UI library from token-based authentication
to npm Trusted Publishing using GitHub Actions OIDC.

### Why
npm has deprecated and revoked classic npm tokens, which breaks our current
publish workflow. Trusted Publishing is the npm-recommended replacement and
removes the need for long-lived npm credentials in CI.

### Changes
- Enable OIDC (`id-token: write`) for the release job
- Ensure npm CLI >= 11.5.1 (required for Trusted Publishing)
- Replace `yarn publish` with `npm publish`
- Remove use of `NODE_AUTH_TOKEN` / npm API token during publish

### Impact
- No change to the published package name or versioning scheme
- No impact to consuming applications (e.g. opal-frontend)
- Publishing is still driven by GitHub Releases

### Follow-up / Notes
- npm package must be configured with a Trusted Publisher entry pointing at this
  repository and the `npm_build.yml` workflow for publishing to succeed.
- This change removes long-lived npm publish credentials from CI and aligns with
npm’s recommended Trusted Publishing (OIDC) approach.

### Testing done
- N/A

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
