### PR TITLE
chore(ci): switch npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm_build.yml
+++ b/.github/workflows/npm_build.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -50,6 +49,9 @@ jobs:
     name: Release and Publish
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository (Release)
         uses: actions/checkout@v6
@@ -65,15 +67,12 @@ jobs:
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
 
       - name: Ensure npm version (Trusted Publishing)
         run: |
           npm --version
           npm i -g npm@11.5.1
           npm --version
-
-
       - name: Install dependencies (Release)
         run: yarn install --frozen-lockfile
 
@@ -83,5 +82,5 @@ jobs:
       - name: Publish version (OIDC via npm)
         working-directory: dist/opal-frontend-common
         run: |
-          npm version "${{ steps.release.outputs.version }}" --no-git-tag-version
+          unset NODE_AUTH_TOKEN
           npm publish --access public


### PR DESCRIPTION
### Jira link
- N/A

### Change description
### What
Updates the release workflow to publish the common UI library to npm using
GitHub Actions OIDC (npm Trusted Publishing) instead of token-based auth.

### Why
npm has deprecated and revoked classic npm tokens, which breaks the existing
publish flow. Trusted Publishing is the npm-recommended replacement and removes
the need for long-lived npm credentials in CI.

### Changes
- Enable OIDC (`id-token: write`) for the release job
- Ensure npm CLI >= 11.5.1 (required for Trusted Publishing)
- Remove token-based publish configuration
- Publish with `npm publish --access public`
- Do not mutate versions in CI (versions are manually bumped)

### Impact
- No change to package name or versioning scheme
- No impact to consuming applications (e.g. opal-frontend)
- Publishing remains driven by GitHub Releases

### Notes
- npm package must be configured with a Trusted Publisher entry pointing at
  this repository and the `npm_build.yml` workflow for publishing to succeed.

### Testing done
- N/A

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
