### PR TITLE
chore(ci): force npm publish to use OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm_build.yml
+++ b/.github/workflows/npm_build.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -66,7 +65,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24.x'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm version (Trusted Publishing)
         run: |
@@ -82,5 +80,15 @@ jobs:
       - name: Publish version (OIDC via npm)
         working-directory: dist/opal-frontend-common
         run: |
+          # Ensure we do NOT publish using token-based auth (classic/granular).
           unset NODE_AUTH_TOKEN
+
+          # Use a fresh npm user config with no auth token to force OIDC Trusted Publishing.
+          export NPM_CONFIG_USERCONFIG="$RUNNER_TEMP/npmrc-noauth"
+          printf "registry=https://registry.npmjs.org/\n" > "$NPM_CONFIG_USERCONFIG"
+
+          # Defensive: remove any auth token entries if something tries to inject them.
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config delete _authToken || true
+
           npm publish --access public


### PR DESCRIPTION
### Jira link
- N/A

### Change description
### What
Hardens the npm publish workflow to ensure publishing uses GitHub Actions OIDC
(npm Trusted Publishing) and cannot fall back to token-based authentication.

### Why
npm classic tokens have been revoked and granular tokens are short-lived.
Our workflow was still implicitly picking up token-based auth via npm config,
causing publishes to fail with "access token expired or revoked".

This change ensures `npm publish` uses OIDC exclusively.

### Changes
- Remove npm registry configuration from `actions/setup-node`
- Explicitly unset `NODE_AUTH_TOKEN` during publish
- Use a clean, no-auth npm user config for the publish step
- Defensively remove any injected npm auth tokens before publishing

### Impact
- No change to package name, versioning, or build output
- No impact to consuming applications
- Publishing remains triggered by GitHub Releases

### Notes
- Requires the npm package to be configured with a Trusted Publisher entry
  pointing at this repository and the `npm_build.yml` workflow.

### Testing done
- N/A

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
