### PR TITLE
PO-2942

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/opal-frontend-common/pipes/monetary/monetary.pipe.spec.ts
+++ b/projects/opal-frontend-common/pipes/monetary/monetary.pipe.spec.ts
@@ -60,6 +60,15 @@ describe('MonetaryPipe', () => {
     expect(result).toBe('-£50.00');
   });
 
+  it('should remove the negative sign when requested', () => {
+    utilsService.convertToMonetaryString.mockReturnValue('-£3,000.00');
+
+    const result = pipe.transform(-3000, true);
+
+    expect(utilsService.convertToMonetaryString).toHaveBeenCalledWith(-3000);
+    expect(result).toBe('£3,000.00');
+  });
+
   it('should handle large values', () => {
     utilsService.convertToMonetaryString.mockReturnValue('£1,234,567.89');
 

--- a/projects/opal-frontend-common/pipes/monetary/monetary.pipe.spec.ts
+++ b/projects/opal-frontend-common/pipes/monetary/monetary.pipe.spec.ts
@@ -1,4 +1,4 @@
-import type { MockedObject } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type MockedObject } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { MonetaryPipe } from './monetary.pipe';
 import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
@@ -60,10 +60,10 @@ describe('MonetaryPipe', () => {
     expect(result).toBe('-£50.00');
   });
 
-  it('should remove the negative sign when requested', () => {
+  it('should remove the minus symbol when requested', () => {
     utilsService.convertToMonetaryString.mockReturnValue('-£3,000.00');
 
-    const result = pipe.transform(-3000, true);
+    const result = pipe.transform(-3000, 'remove-minus-symbol');
 
     expect(utilsService.convertToMonetaryString).toHaveBeenCalledWith(-3000);
     expect(result).toBe('£3,000.00');

--- a/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
+++ b/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform, inject } from '@angular/core';
 import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 
-type MonetaryFormat = 'default' | 'remove-negative-symbol';
+type MonetaryFormat = 'default' | 'remove-minus-symbol';
 
 @Pipe({
   name: 'monetary',
@@ -13,6 +13,6 @@ export class MonetaryPipe implements PipeTransform {
   transform(value: number | string, format: MonetaryFormat = 'default'): string {
     const monetaryValue = this.utilsService.convertToMonetaryString(value);
 
-    return format === 'remove-negative-symbol' ? monetaryValue.replace(/^-/, '') : monetaryValue;
+    return format === 'remove-minus-symbol' ? monetaryValue.replace(/^-/, '') : monetaryValue;
   }
 }

--- a/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
+++ b/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
@@ -7,6 +7,14 @@ type MonetaryFormat = 'default' | 'remove-minus-symbol';
   name: 'monetary',
   standalone: true,
 })
+
+/**
+ * Converts a numeric or string value into a monetary string.
+ *
+ * @param value The value to format as currency.
+ * @param format The output format. Use `remove-minus-symbol` to strip a leading minus sign.
+ * @returns The formatted monetary value.
+ */
 export class MonetaryPipe implements PipeTransform {
   private readonly utilsService: UtilsService = inject(UtilsService);
 

--- a/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
+++ b/projects/opal-frontend-common/pipes/monetary/monetary.pipe.ts
@@ -1,14 +1,18 @@
 import { Pipe, PipeTransform, inject } from '@angular/core';
 import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 
+type MonetaryFormat = 'default' | 'remove-negative-symbol';
+
 @Pipe({
   name: 'monetary',
   standalone: true,
 })
 export class MonetaryPipe implements PipeTransform {
-  private readonly utilsService = inject(UtilsService);
+  private readonly utilsService: UtilsService = inject(UtilsService);
 
-  transform(value: number | string): string {
-    return this.utilsService.convertToMonetaryString(value);
+  transform(value: number | string, format: MonetaryFormat = 'default'): string {
+    const monetaryValue = this.utilsService.convertToMonetaryString(value);
+
+    return format === 'remove-negative-symbol' ? monetaryValue.replace(/^-/, '') : monetaryValue;
   }
 }


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PO-2942

### Change description

Implemented functionality to remove `-` symbol from `MonetaryPipe`, in order to handle situations in which we do not want to show a negative value e.g. summary tiles within the  `fines-acc-defendant-details` section.


### Testing done

- Added unit test to handle additional argument and formatting. 

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
