### PR TITLE
PO-3719 add reusable feature flag guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+import { LaunchDarklyService } from '@hmcts/opal-frontend-common/services/launch-darkly-service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { featureFlagGuard } from './feature-flag.guard';
+
+describe('featureFlagGuard', () => {
+  let featureFlagsMock: ReturnType<typeof vi.fn>;
+  let initializeLaunchDarklyFlagsMock: ReturnType<typeof vi.fn>;
+
+  const runGuard = (flagKey: string) =>
+    TestBed.runInInjectionContext(() =>
+      featureFlagGuard(flagKey)({} as ActivatedRouteSnapshot, {} as RouterStateSnapshot),
+    );
+
+  beforeEach(() => {
+    featureFlagsMock = vi.fn().mockReturnValue({ 'release-1a': true });
+    initializeLaunchDarklyFlagsMock = vi.fn().mockResolvedValue(undefined);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: GlobalStore,
+          useValue: {
+            featureFlags: featureFlagsMock,
+          },
+        },
+        {
+          provide: LaunchDarklyService,
+          useValue: {
+            initializeLaunchDarklyFlags: initializeLaunchDarklyFlagsMock,
+          },
+        },
+      ],
+    });
+  });
+
+  it('should return true when the requested feature flag is enabled', async () => {
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(true);
+    expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should return false when the requested feature flag is disabled', async () => {
+    featureFlagsMock.mockReturnValue({ 'release-1a': false });
+
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(false);
+    expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+  });
+
+  it('should initialize LaunchDarkly flags when the requested feature flag is missing', async () => {
+    featureFlagsMock.mockReturnValueOnce({}).mockReturnValue({ 'release-1a': true });
+
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(true);
+    expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return false when the requested feature flag is still missing after LaunchDarkly initializes', async () => {
+    featureFlagsMock.mockReturnValue({});
+
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(false);
+    expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return false when LaunchDarkly initialization fails', async () => {
+    featureFlagsMock.mockReturnValue({});
+    initializeLaunchDarklyFlagsMock.mockRejectedValue(new Error('LaunchDarkly failed'));
+
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(false);
+  });
+
+  it('should check the feature flag key passed to the guard', async () => {
+    featureFlagsMock.mockReturnValue({ 'release-1c': true });
+
+    const result = await runGuard('release-1c');
+
+    expect(result).toBe(true);
+    expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+  });
+});

--- a/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.spec.ts
@@ -7,6 +7,7 @@ import { featureFlagGuard } from './feature-flag.guard';
 
 describe('featureFlagGuard', () => {
   let featureFlagsMock: ReturnType<typeof vi.fn>;
+  let initializeLaunchDarklyClientMock: ReturnType<typeof vi.fn>;
   let initializeLaunchDarklyFlagsMock: ReturnType<typeof vi.fn>;
 
   const runGuard = (flagKey: string) =>
@@ -16,6 +17,7 @@ describe('featureFlagGuard', () => {
 
   beforeEach(() => {
     featureFlagsMock = vi.fn().mockReturnValue({ 'release-1a': true });
+    initializeLaunchDarklyClientMock = vi.fn();
     initializeLaunchDarklyFlagsMock = vi.fn().mockResolvedValue(undefined);
 
     TestBed.configureTestingModule({
@@ -29,6 +31,7 @@ describe('featureFlagGuard', () => {
         {
           provide: LaunchDarklyService,
           useValue: {
+            initializeLaunchDarklyClient: initializeLaunchDarklyClientMock,
             initializeLaunchDarklyFlags: initializeLaunchDarklyFlagsMock,
           },
         },
@@ -41,6 +44,7 @@ describe('featureFlagGuard', () => {
 
     expect(result).toBe(true);
     expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+    expect(initializeLaunchDarklyClientMock).not.toHaveBeenCalled();
   });
 
   it('should return false when the requested feature flag is disabled', async () => {
@@ -50,6 +54,7 @@ describe('featureFlagGuard', () => {
 
     expect(result).toBe(false);
     expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+    expect(initializeLaunchDarklyClientMock).not.toHaveBeenCalled();
   });
 
   it('should initialize LaunchDarkly flags when the requested feature flag is missing', async () => {
@@ -59,6 +64,17 @@ describe('featureFlagGuard', () => {
 
     expect(result).toBe(true);
     expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(1);
+    expect(initializeLaunchDarklyClientMock).not.toHaveBeenCalled();
+  });
+
+  it('should initialize the LaunchDarkly client and retry flags when the requested feature flag remains missing', async () => {
+    featureFlagsMock.mockReturnValueOnce({}).mockReturnValueOnce({}).mockReturnValue({ 'release-1a': true });
+
+    const result = await runGuard('release-1a');
+
+    expect(result).toBe(true);
+    expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(2);
+    expect(initializeLaunchDarklyClientMock).toHaveBeenCalledTimes(1);
   });
 
   it('should return false when the requested feature flag is still missing after LaunchDarkly initializes', async () => {
@@ -67,16 +83,25 @@ describe('featureFlagGuard', () => {
     const result = await runGuard('release-1a');
 
     expect(result).toBe(false);
-    expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(1);
+    expect(initializeLaunchDarklyFlagsMock).toHaveBeenCalledTimes(2);
+    expect(initializeLaunchDarklyClientMock).toHaveBeenCalledTimes(1);
   });
 
   it('should return false when LaunchDarkly initialization fails', async () => {
+    const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     featureFlagsMock.mockReturnValue({});
-    initializeLaunchDarklyFlagsMock.mockRejectedValue(new Error('LaunchDarkly failed'));
+    const error = new Error('LaunchDarkly failed');
+    initializeLaunchDarklyFlagsMock.mockRejectedValue(error);
 
     const result = await runGuard('release-1a');
 
     expect(result).toBe(false);
+    expect(initializeLaunchDarklyClientMock).not.toHaveBeenCalled();
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      'Feature flag "release-1a" could not be resolved. Access denied by featureFlagGuard.',
+      error,
+    );
+    consoleWarnMock.mockRestore();
   });
 
   it('should check the feature flag key passed to the guard', async () => {
@@ -86,5 +111,6 @@ describe('featureFlagGuard', () => {
 
     expect(result).toBe(true);
     expect(initializeLaunchDarklyFlagsMock).not.toHaveBeenCalled();
+    expect(initializeLaunchDarklyClientMock).not.toHaveBeenCalled();
   });
 });

--- a/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
@@ -28,6 +28,14 @@ export function featureFlagGuard(flagKey: string): CanActivateFn {
 
     try {
       await launchDarklyService.initializeLaunchDarklyFlags();
+
+      if (isFeatureFlagPopulated(globalStore.featureFlags(), flagKey)) {
+        return isFeatureFlagEnabled(globalStore.featureFlags(), flagKey);
+      }
+
+      launchDarklyService.initializeLaunchDarklyClient();
+      await launchDarklyService.initializeLaunchDarklyFlags();
+
       return isFeatureFlagEnabled(globalStore.featureFlags(), flagKey);
     } catch (error) {
       console.warn(`Feature flag "${flagKey}" could not be resolved. Access denied by featureFlagGuard.`, error);

--- a/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
@@ -1,0 +1,30 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { LDFlagSet } from 'launchdarkly-js-client-sdk';
+import { LaunchDarklyService } from '@hmcts/opal-frontend-common/services/launch-darkly-service';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+
+const isFeatureFlagPopulated = (featureFlags: LDFlagSet | undefined, flagKey: string): boolean =>
+  featureFlags?.[flagKey] !== undefined;
+
+const isFeatureFlagEnabled = (featureFlags: LDFlagSet | undefined, flagKey: string): boolean =>
+  featureFlags?.[flagKey] === true;
+
+export function featureFlagGuard(flagKey: string): CanActivateFn {
+  return async () => {
+    const globalStore = inject(GlobalStore);
+    const launchDarklyService = inject(LaunchDarklyService);
+
+    if (isFeatureFlagPopulated(globalStore.featureFlags(), flagKey)) {
+      return isFeatureFlagEnabled(globalStore.featureFlags(), flagKey);
+    }
+
+    try {
+      await launchDarklyService.initializeLaunchDarklyFlags();
+      return isFeatureFlagEnabled(globalStore.featureFlags(), flagKey);
+    } catch (error) {
+      console.warn(`Feature flag "${flagKey}" could not be resolved. Access denied by featureFlagGuard.`, error);
+      return false;
+    }
+  };
+}

--- a/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/feature-flag.guard.ts
@@ -10,6 +10,13 @@ const isFeatureFlagPopulated = (featureFlags: LDFlagSet | undefined, flagKey: st
 const isFeatureFlagEnabled = (featureFlags: LDFlagSet | undefined, flagKey: string): boolean =>
   featureFlags?.[flagKey] === true;
 
+/**
+ * Creates a route guard that checks if a specific feature flag is enabled before allowing access.
+ *
+ * @param flagKey - The key of the feature flag to check
+ * @returns A CanActivateFn that returns true if the feature flag is enabled, false otherwise
+ *
+ */
 export function featureFlagGuard(flagKey: string): CanActivateFn {
   return async () => {
     const globalStore = inject(GlobalStore);

--- a/projects/opal-frontend-common/guards/feature-flag/ng-package.json
+++ b/projects/opal-frontend-common/guards/feature-flag/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/projects/opal-frontend-common/guards/feature-flag/package.json
+++ b/projects/opal-frontend-common/guards/feature-flag/package.json
@@ -1,0 +1,5 @@
+{
+  "sideEffects": false,
+  "module": "../../../dist/opal-frontend-common/fesm2022/hmcts-opal-frontend-common-guards-feature-flag.mjs",
+  "typings": "../../../dist/opal-frontend-common/guards/feature-flag/index.d.ts"
+}

--- a/projects/opal-frontend-common/guards/feature-flag/public-api.ts
+++ b/projects/opal-frontend-common/guards/feature-flag/public-api.ts
@@ -1,0 +1,1 @@
+export * from './feature-flag.guard';

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -382,6 +382,9 @@
     "./guards/can-deactivate/types": {
       "import": "./fesm2022/hmcts-opal-frontend-common-guards-can-deactivate-types.mjs"
     },
+    "./guards/feature-flag": {
+      "import": "./fesm2022/hmcts-opal-frontend-common-guards-feature-flag.mjs"
+    },
     "./guards/has-flow-state": {
       "import": "./fesm2022/hmcts-opal-frontend-common-guards-has-flow-state.mjs"
     },

--- a/projects/opal-frontend-common/services/launch-darkly-service/launch-darkly.service.spec.ts
+++ b/projects/opal-frontend-common/services/launch-darkly-service/launch-darkly.service.spec.ts
@@ -56,6 +56,15 @@ describe('LaunchDarklyService', () => {
     expect(service['ldClient']).toBeDefined();
   });
 
+  it('should not recreate the LaunchDarkly client if it has already been initialized', () => {
+    service.initializeLaunchDarklyClient();
+    const ldClient = service['ldClient'];
+
+    service.initializeLaunchDarklyClient();
+
+    expect(service['ldClient']).toBe(ldClient);
+  });
+
   it('should not initialize LaunchDarkly client if no client id', () => {
     globalStore.setLaunchDarklyConfig({
       enabled: true,

--- a/projects/opal-frontend-common/services/launch-darkly-service/launch-darkly.service.ts
+++ b/projects/opal-frontend-common/services/launch-darkly-service/launch-darkly.service.ts
@@ -75,6 +75,10 @@ export class LaunchDarklyService implements OnDestroy {
    * If a stored LaunchDarkly client ID exists, it initializes the client with the ID and anonymous mode enabled.
    */
   public initializeLaunchDarklyClient(): void {
+    if (this.ldClient) {
+      return;
+    }
+
     if (this.globalStore.launchDarklyConfig()) {
       const { enabled, clientId } = this.globalStore.launchDarklyConfig();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -334,6 +334,7 @@
       "@hmcts/opal-frontend-common/guards/can-deactivate/types": [
         "./dist/opal-frontend-common/guards/can-deactivate/types"
       ],
+      "@hmcts/opal-frontend-common/guards/feature-flag": ["./dist/opal-frontend-common/guards/feature-flag"],
       "@hmcts/opal-frontend-common/guards/has-flow-state": ["./dist/opal-frontend-common/guards/has-flow-state"],
       "@hmcts/opal-frontend-common/guards/has-url-state-match": [
         "./dist/opal-frontend-common/guards/has-url-state-match"
@@ -464,7 +465,9 @@
         "./dist/opal-frontend-common/validators/pattern-validator"
       ],
       "@hmcts/opal-frontend-common/validators/valid-value": ["./dist/opal-frontend-common/validators/valid-value"],
-      "@hmcts/opal-frontend-common/validators/non-zero-value": ["./dist/opal-frontend-common/validators/non-zero-value"],
+      "@hmcts/opal-frontend-common/validators/non-zero-value": [
+        "./dist/opal-frontend-common/validators/non-zero-value"
+      ],
 
       "@hmcts/opal-frontend-common/types": ["./dist/opal-frontend-common/types"]
     },


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/PO-3719

### Change description

- Added a new reusable featureFlagGuard(flagKey) guard so apps can check any LaunchDarkly flag, for example `release-1a`, `release-1b`, `release-1c-enforcement-operational-reporting` etc. without the need to create one guard per flag.

- Moved the feature-flag checking logic into the common UI library in order to make the flag hydration/checking contract shared and consistent across consuming apps, instead of duplicating repo-specific logic.

### Testing done

- Added unit tests for populated, missing, hydrated, disabled, and error cases.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
