### PR TITLE
fix(auth): make SSO redirect SSR-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/guards/auth/auth.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/auth/auth.guard.spec.ts
@@ -1,4 +1,6 @@
+import { DOCUMENT } from '@angular/common';
 import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { PLATFORM_ID } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CanActivateFn, Router, UrlSegment, UrlSegmentGroup, UrlTree } from '@angular/router';
 import { authGuard, REDIRECT_TO_SSO } from './auth.guard';
@@ -8,6 +10,7 @@ import { GlobalStoreType } from '@hmcts/opal-frontend-common/stores/global/types
 import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
 import { runAuthGuardWithContext } from '../helpers/run-auth-guard-with-context';
 import { getGuardWithDummyUrl } from '../helpers/get-guard-with-dummy-url';
+import { SSO_ENDPOINTS } from '@hmcts/opal-frontend-common/services/auth-service/constants';
 
 describe('authGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) =>
@@ -94,17 +97,47 @@ describe('authGuard', () => {
   });
 
   describe('REDIRECT_TO_SSO', () => {
-    it('should trigger the default redirect logic', () => {
+    const setupDefaultRedirectToSso = ({
+      platformId,
+      document,
+    }: {
+      platformId: 'browser' | 'server';
+      document: { location: { href: string } };
+    }) => {
       TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: PLATFORM_ID, useValue: platformId },
+          { provide: DOCUMENT, useValue: document },
+        ],
+      });
 
-      const redirectToSso = TestBed.inject(REDIRECT_TO_SSO);
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      return TestBed.inject(REDIRECT_TO_SSO);
+    };
+
+    it('should set the injected document location href to the SSO login endpoint on the browser platform', () => {
+      const document = { location: { href: '' } };
+
+      const redirectToSso = setupDefaultRedirectToSso({ platformId: 'browser', document });
+
+      redirectToSso();
+
+      expect(document.location.href).toBe(SSO_ENDPOINTS.login);
+    });
+
+    it('should not throw or set the injected document location href on the server platform', () => {
+      const document = { location: { href: '' } };
+      vi.stubGlobal('location', undefined);
+
+      const redirectToSso = setupDefaultRedirectToSso({ platformId: 'server', document });
 
       try {
         expect(() => redirectToSso()).not.toThrow();
       } finally {
-        consoleErrorSpy.mockRestore();
+        vi.unstubAllGlobals();
       }
+
+      expect(document.location.href).toBe('');
     });
   });
 });

--- a/projects/opal-frontend-common/guards/auth/auth.guard.ts
+++ b/projects/opal-frontend-common/guards/auth/auth.guard.ts
@@ -1,5 +1,6 @@
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { CanActivateFn, Router } from '@angular/router';
-import { inject, InjectionToken } from '@angular/core';
+import { inject, InjectionToken, PLATFORM_ID } from '@angular/core';
 import { map, catchError, of } from 'rxjs';
 import { PAGES_ROUTING_PATHS } from '@hmcts/opal-frontend-common/pages/routing/constants';
 import { AuthService } from '@hmcts/opal-frontend-common/services/auth-service';
@@ -9,8 +10,15 @@ import { SSO_ENDPOINTS } from '@hmcts/opal-frontend-common/services/auth-service
 
 export const REDIRECT_TO_SSO = new InjectionToken<() => void>('redirectToSsoLogin', {
   providedIn: 'root',
-  factory: () => () => {
-    globalThis.location.href = SSO_ENDPOINTS.login;
+  factory: () => {
+    const document = inject(DOCUMENT);
+    const platformId = inject(PLATFORM_ID);
+
+    return () => {
+      if (isPlatformBrowser(platformId)) {
+        document.location.href = SSO_ENDPOINTS.login;
+      }
+    };
   },
 });
 

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.79",
+  "version": "0.0.90",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.90",
+  "version": "0.0.80",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Jira link
- N/A

### Change description
- Makes the default `REDIRECT_TO_SSO` token browser-only using `PLATFORM_ID`, `isPlatformBrowser`, and injected `DOCUMENT`.
- Preserves browser redirect behavior to `SSO_ENDPOINTS.login`.
- No-ops safely during Angular SSR so `globalThis.location` is no longer required.
- Adds browser/server unit coverage for the redirect token and keeps the auth guard SSO error-path coverage.

### Testing done
- [x] `yarn vitest run --config vitest.vscode.config.ts`
- [x] `yarn lint`
- [x] `yarn build`

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
