### PR TITLE
PO-5773 Tech Debt - Create reusable business-unit route permission guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common-ui-lib",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
@@ -69,7 +69,7 @@ export const routes: Routes = [
     loadComponent: () => import('./payment-terms-amend.component').then((c) => c.PaymentTermsAmendComponent),
     data: {
       routePermissionId: [77],
-      accessDeniedPath: 'payment-terms/denied/permission',
+      accessDeniedPath: '/payment-terms/denied/permission',
     },
   },
 ];

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
@@ -59,21 +59,35 @@ Routes must declare the permission ids required for that route using `routePermi
 Use `accessDeniedPath` when the route should redirect to a feature-specific denied page. Absolute paths are resolved from the app root. Relative paths are resolved from the current route's parent when one exists, or from the current route when there is no parent.
 
 ```typescript
+import { type Routes } from '@angular/router';
 import { authGuard } from '@hmcts/opal-frontend-common/guards/auth';
 import { businessUnitRoutePermissionsGuard } from '@hmcts/opal-frontend-common/guards/business-unit-route-permissions';
+import { accountStateGuard } from './account-state.guard';
 
 export const routes: Routes = [
   {
-    path: 'account/:accountId/payment-terms/amend',
-    canActivate: [authGuard, businessUnitRoutePermissionsGuard, accountStateGuard],
-    loadComponent: () => import('./payment-terms-amend.component').then((c) => c.PaymentTermsAmendComponent),
-    data: {
-      routePermissionId: [77],
-      accessDeniedPath: '/payment-terms/denied/permission',
-    },
+    path: 'account/:accountId',
+    children: [
+      {
+        path: 'payment-terms/amend',
+        canActivate: [authGuard, businessUnitRoutePermissionsGuard, accountStateGuard],
+        loadComponent: () => import('./payment-terms-amend.component').then((c) => c.PaymentTermsAmendComponent),
+        data: {
+          routePermissionId: [77],
+          accessDeniedPath: 'payment-terms/denied/permission',
+        },
+      },
+      {
+        path: 'payment-terms/denied/:type',
+        loadComponent: () =>
+          import('./payment-terms-denied.component').then((c) => c.PaymentTermsDeniedComponent),
+      },
+    ],
   },
 ];
 ```
+
+In an account flow, use a relative `accessDeniedPath` so the redirect keeps the current account route, including the account id. Use an absolute `accessDeniedPath`, starting with `/`, only when the denied page lives at the app root.
 
 `routePermissionId` can be either a number or an array of numbers. Access is allowed when the user has at least one declared permission in the resolved business unit.
 
@@ -88,6 +102,8 @@ Recommended ordering:
 ```typescript
 canActivate: [authGuard, businessUnitRoutePermissionsGuard, accountStateGuard];
 ```
+
+If authentication is already enforced by a parent route, keep `businessUnitRoutePermissionsGuard` before the route-state guard on the child route.
 
 This keeps the checks in this order:
 

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/README.md
@@ -1,0 +1,108 @@
+# Business Unit Route Permissions Guard
+
+`businessUnitRoutePermissionsGuard` protects Angular routes by checking whether the logged-in user has one of the route's required permissions in the business unit resolved for the current route.
+
+Use this guard when a route needs business-unit-specific permission checks rather than global user permission checks.
+
+## Installation
+
+```typescript
+import {
+  BUSINESS_UNIT_ID_RESOLVER,
+  businessUnitRoutePermissionsGuard,
+  type BusinessUnitIdResolver,
+} from '@hmcts/opal-frontend-common/guards/business-unit-route-permissions';
+```
+
+## Provider Setup
+
+Consuming applications must provide `BUSINESS_UNIT_ID_RESOLVER`. The resolver is application-specific because only the consuming app knows how to derive the business unit from its route, store, or API state.
+
+```typescript
+import { Injectable } from '@angular/core';
+import { type ActivatedRouteSnapshot, type MaybeAsync } from '@angular/router';
+import { type BusinessUnitIdResolver } from '@hmcts/opal-frontend-common/guards/business-unit-route-permissions';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AccountBusinessUnitResolver implements BusinessUnitIdResolver {
+  public resolveBusinessUnitId(route: ActivatedRouteSnapshot): MaybeAsync<number | null> {
+    const businessUnitId = Number(route.paramMap.get('businessUnitId'));
+
+    return Number.isFinite(businessUnitId) && businessUnitId > 0 ? businessUnitId : null;
+  }
+}
+```
+
+Register the resolver once in the consuming app's providers:
+
+```typescript
+import { type ApplicationConfig } from '@angular/core';
+import { BUSINESS_UNIT_ID_RESOLVER } from '@hmcts/opal-frontend-common/guards/business-unit-route-permissions';
+import { AccountBusinessUnitResolver } from './account-business-unit.resolver';
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    {
+      provide: BUSINESS_UNIT_ID_RESOLVER,
+      useExisting: AccountBusinessUnitResolver,
+    },
+  ],
+};
+```
+
+## Route Data
+
+Routes must declare the permission ids required for that route using `routePermissionId`.
+
+Use `accessDeniedPath` when the route should redirect to a feature-specific denied page. Absolute paths are resolved from the app root. Relative paths are resolved from the current route's parent when one exists, or from the current route when there is no parent.
+
+```typescript
+import { authGuard } from '@hmcts/opal-frontend-common/guards/auth';
+import { businessUnitRoutePermissionsGuard } from '@hmcts/opal-frontend-common/guards/business-unit-route-permissions';
+
+export const routes: Routes = [
+  {
+    path: 'account/:accountId/payment-terms/amend',
+    canActivate: [authGuard, businessUnitRoutePermissionsGuard, accountStateGuard],
+    loadComponent: () => import('./payment-terms-amend.component').then((c) => c.PaymentTermsAmendComponent),
+    data: {
+      routePermissionId: [77],
+      accessDeniedPath: 'payment-terms/denied/permission',
+    },
+  },
+];
+```
+
+`routePermissionId` can be either a number or an array of numbers. Access is allowed when the user has at least one declared permission in the resolved business unit.
+
+If no `accessDeniedPath` is supplied, the guard redirects to the common `/access-denied` page.
+
+## Guard Ordering
+
+Place this guard after authentication and before route-state guards that assume the user is allowed to enter the journey.
+
+Recommended ordering:
+
+```typescript
+canActivate: [authGuard, businessUnitRoutePermissionsGuard, accountStateGuard];
+```
+
+This keeps the checks in this order:
+
+1. The user is authenticated.
+2. The user has the required permission in the resolved business unit.
+3. The route has the application state needed by the feature.
+
+## Resolver Guidance
+
+The resolver should return a positive numeric business unit id when the route context is valid.
+
+Return `null` when the business unit cannot be determined. The guard treats `null`, non-numeric values, non-finite values, and values less than or equal to zero as permission failures and redirects to the denied page.
+
+The resolver can return a synchronous value, a `Promise`, or an `Observable`.
+
+## Testing
+
+When testing consuming routes, cover both direct navigation and in-journey navigation. Direct navigation is important because guards run before route resolvers, so the business unit id must be available through the `BUSINESS_UNIT_ID_RESOLVER` contract.

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { of } from 'rxjs';
+import { businessUnitRoutePermissionsGuard, BUSINESS_UNIT_ID_RESOLVER } from './business-unit-route-permissions.guard';
+import { PermissionsService } from '@hmcts/opal-frontend-common/services/permissions-service';
+import { OpalUserService } from '@hmcts/opal-frontend-common/services/opal-user-service';
+
+function createRoute(routePermissionId?: number[] | number, accessDeniedPath?: string): ActivatedRouteSnapshot {
+  const route = new ActivatedRouteSnapshot();
+  route.data = {
+    ...(routePermissionId === undefined ? {} : { routePermissionId }),
+    ...(accessDeniedPath === undefined ? {} : { accessDeniedPath }),
+  };
+  return route;
+}
+
+describe('businessUnitRoutePermissionsGuard', () => {
+  let createUrlTreeMock: Mock;
+  let hasBusinessUnitPermissionAccessMock: ReturnType<typeof vi.fn>;
+  let getLoggedInUserStateMock: ReturnType<typeof vi.fn>;
+  let resolveBusinessUnitIdMock: ReturnType<typeof vi.fn>;
+
+  const userState = {
+    business_unit_users: [
+      {
+        business_unit_user_id: 'BU-123',
+        business_unit_id: 123,
+        permissions: [{ permission_id: 77, permission_name: 'Account Maintenance' }],
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    createUrlTreeMock = vi.fn().mockName('Router.createUrlTree');
+    hasBusinessUnitPermissionAccessMock = vi.fn().mockName('PermissionsService.hasBusinessUnitPermissionAccess');
+    getLoggedInUserStateMock = vi.fn().mockName('OpalUserService.getLoggedInUserState');
+    resolveBusinessUnitIdMock = vi.fn().mockName('BusinessUnitIdResolver.resolveBusinessUnitId');
+
+    getLoggedInUserStateMock.mockReturnValue(of(userState));
+    resolveBusinessUnitIdMock.mockReturnValue(Promise.resolve(123));
+    hasBusinessUnitPermissionAccessMock.mockReturnValue(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            createUrlTree: createUrlTreeMock,
+          },
+        },
+        {
+          provide: PermissionsService,
+          useValue: {
+            hasBusinessUnitPermissionAccess: hasBusinessUnitPermissionAccessMock,
+          },
+        },
+        {
+          provide: OpalUserService,
+          useValue: {
+            getLoggedInUserState: getLoggedInUserStateMock,
+          },
+        },
+        {
+          provide: BUSINESS_UNIT_ID_RESOLVER,
+          useValue: {
+            resolveBusinessUnitId: resolveBusinessUnitIdMock,
+          },
+        },
+      ],
+    });
+  });
+
+  it('should allow access when the route does not require any permissions', async () => {
+    const route = createRoute();
+
+    const result = await TestBed.runInInjectionContext(() =>
+      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(true);
+    expect(getLoggedInUserStateMock).not.toHaveBeenCalled();
+    expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
+  });
+
+  it('should allow access when the user has the required permission in the resolved business unit', async () => {
+    const route = createRoute([77]);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(true);
+    expect(getLoggedInUserStateMock).toHaveBeenCalledTimes(1);
+    expect(resolveBusinessUnitIdMock).toHaveBeenCalledWith(route);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
+  });
+
+  it('should redirect to the configured access denied path when the user lacks the required permission', async () => {
+    const expectedUrlTree = new UrlTree();
+    hasBusinessUnitPermissionAccessMock.mockReturnValue(false);
+    createUrlTreeMock.mockReturnValue(expectedUrlTree);
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await TestBed.runInInjectionContext(() =>
+      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(expectedUrlTree);
+    expect(createUrlTreeMock).toHaveBeenCalledWith(['/custom-denied']);
+  });
+
+  it('should redirect when the resolver cannot determine the business unit', async () => {
+    const expectedUrlTree = new UrlTree();
+    resolveBusinessUnitIdMock.mockResolvedValueOnce(null);
+    createUrlTreeMock.mockReturnValue(expectedUrlTree);
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await TestBed.runInInjectionContext(() =>
+      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(expectedUrlTree);
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(createUrlTreeMock).toHaveBeenCalledWith(['/custom-denied']);
+  });
+
+  it('should redirect when the user has no business unit roles', async () => {
+    const expectedUrlTree = new UrlTree();
+    getLoggedInUserStateMock.mockReturnValue(of({ business_unit_users: [] }));
+    createUrlTreeMock.mockReturnValue(expectedUrlTree);
+    const route = createRoute([77]);
+
+    const result = await TestBed.runInInjectionContext(() =>
+      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
+    );
+
+    expect(result).toBe(expectedUrlTree);
+    expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(createUrlTreeMock).toHaveBeenCalledWith([`/${'access-denied'}`]);
+  });
+});

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -20,7 +20,7 @@ import { OpalUserService } from '@hmcts/opal-frontend-common/services/opal-user-
 })
 class TestRouteComponent {}
 
-function createRoute(routePermissionId?: number[] | number, accessDeniedPath?: string): ActivatedRouteSnapshot {
+function createRoute(routePermissionId?: unknown, accessDeniedPath?: string): ActivatedRouteSnapshot {
   const route = new ActivatedRouteSnapshot();
   route.data = {
     ...(routePermissionId === undefined ? {} : { routePermissionId }),
@@ -136,6 +136,36 @@ describe('businessUnitRoutePermissionsGuard', () => {
     expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
   });
 
+  it('should allow access when the route declares a single permission id', async () => {
+    const route = createRoute(77);
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
+  });
+
+  it('should ignore invalid permission ids declared alongside valid route permissions', async () => {
+    const route = createRoute([77, 'invalid-permission-id', null]);
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledTimes(1);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
+  });
+
+  it('should allow access when any declared route permission exists in the resolved business unit', async () => {
+    hasBusinessUnitPermissionAccessMock.mockReturnValueOnce(false).mockReturnValueOnce(true);
+    const route = createRoute([55, 77]);
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(55, 123, userState.business_unit_users);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
+  });
+
   it('should allow access when the business unit resolver returns an observable', async () => {
     resolveBusinessUnitIdMock.mockReturnValue(of(123));
     const route = createRoute([77]);
@@ -179,6 +209,28 @@ describe('businessUnitRoutePermissionsGuard', () => {
     expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
   });
 
+  it('should redirect when the resolver returns an invalid business unit id', async () => {
+    resolveBusinessUnitIdMock.mockResolvedValueOnce(0);
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
+  });
+
+  it('should redirect when the resolver returns a non-finite business unit id', async () => {
+    resolveBusinessUnitIdMock.mockResolvedValueOnce(Infinity);
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
+  });
+
   it('should redirect when the user has no business unit roles', async () => {
     getLoggedInUserStateMock.mockReturnValue(of({ business_unit_users: [] }));
     const route = createRoute([77]);
@@ -189,5 +241,30 @@ describe('businessUnitRoutePermissionsGuard', () => {
     expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
     expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
     expect(router.serializeUrl(result as UrlTree)).toBe('/access-denied');
+  });
+
+  it('should redirect when user state cannot be loaded', async () => {
+    getLoggedInUserStateMock.mockImplementationOnce(() => {
+      throw new Error('User state failed');
+    });
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
+  });
+
+  it('should redirect when the business unit resolver fails', async () => {
+    resolveBusinessUnitIdMock.mockRejectedValueOnce(new Error('Resolver failed'));
+    const route = createRoute([77], '/custom-denied');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
   });
 });

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -200,7 +200,11 @@ describe('businessUnitRoutePermissionsGuard', () => {
 
   it('should redirect from the current route when a relative access denied path has no parent route', async () => {
     hasBusinessUnitPermissionAccessMock.mockReturnValue(false);
-    const route = createRoute([77], 'custom-denied');
+    const route = router.routerState.snapshot.root;
+    route.data = {
+      routePermissionId: [77],
+      accessDeniedPath: 'custom-denied',
+    };
 
     const result = await runGuard(route);
 

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -198,6 +198,16 @@ describe('businessUnitRoutePermissionsGuard', () => {
     );
   });
 
+  it('should redirect from the current route when a relative access denied path has no parent route', async () => {
+    hasBusinessUnitPermissionAccessMock.mockReturnValue(false);
+    const route = createRoute([77], 'custom-denied');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
+  });
+
   it('should redirect when the resolver cannot determine the business unit', async () => {
     resolveBusinessUnitIdMock.mockResolvedValueOnce(null);
     const route = createRoute([77], '/custom-denied');
@@ -233,6 +243,18 @@ describe('businessUnitRoutePermissionsGuard', () => {
 
   it('should redirect when the user has no business unit roles', async () => {
     getLoggedInUserStateMock.mockReturnValue(of({ business_unit_users: [] }));
+    const route = createRoute([77]);
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
+    expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
+    expect(router.serializeUrl(result as UrlTree)).toBe('/access-denied');
+  });
+
+  it('should redirect when the user state has no business unit users', async () => {
+    getLoggedInUserStateMock.mockReturnValue(of({}));
     const route = createRoute([77]);
 
     const result = await runGuard(route);

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
   ActivatedRouteSnapshot,
@@ -12,6 +13,12 @@ import { of } from 'rxjs';
 import { businessUnitRoutePermissionsGuard, BUSINESS_UNIT_ID_RESOLVER } from './business-unit-route-permissions.guard';
 import { PermissionsService } from '@hmcts/opal-frontend-common/services/permissions-service';
 import { OpalUserService } from '@hmcts/opal-frontend-common/services/opal-user-service';
+
+@Component({
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TestRouteComponent {}
 
 function createRoute(routePermissionId?: number[] | number, accessDeniedPath?: string): ActivatedRouteSnapshot {
   const route = new ActivatedRouteSnapshot();
@@ -44,6 +51,7 @@ describe('businessUnitRoutePermissionsGuard', () => {
       children: [
         {
           path: 'payment-terms/amend',
+          component: TestRouteComponent,
           data: {
             routePermissionId: [77],
             accessDeniedPath: 'payment-terms/denied/permission',
@@ -51,6 +59,7 @@ describe('businessUnitRoutePermissionsGuard', () => {
         },
         {
           path: 'payment-terms/denied/:type',
+          component: TestRouteComponent,
         },
       ],
     },

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.spec.ts
@@ -1,6 +1,13 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import {
+  ActivatedRouteSnapshot,
+  provideRouter,
+  Router,
+  RouterStateSnapshot,
+  type Routes,
+  UrlTree,
+} from '@angular/router';
 import { of } from 'rxjs';
 import { businessUnitRoutePermissionsGuard, BUSINESS_UNIT_ID_RESOLVER } from './business-unit-route-permissions.guard';
 import { PermissionsService } from '@hmcts/opal-frontend-common/services/permissions-service';
@@ -16,7 +23,7 @@ function createRoute(routePermissionId?: number[] | number, accessDeniedPath?: s
 }
 
 describe('businessUnitRoutePermissionsGuard', () => {
-  let createUrlTreeMock: Mock;
+  let router: Router;
   let hasBusinessUnitPermissionAccessMock: ReturnType<typeof vi.fn>;
   let getLoggedInUserStateMock: ReturnType<typeof vi.fn>;
   let resolveBusinessUnitIdMock: ReturnType<typeof vi.fn>;
@@ -31,8 +38,39 @@ describe('businessUnitRoutePermissionsGuard', () => {
     ],
   };
 
+  const accountRoutes: Routes = [
+    {
+      path: 'fines/account/defendant/:accountId',
+      children: [
+        {
+          path: 'payment-terms/amend',
+          data: {
+            routePermissionId: [77],
+            accessDeniedPath: 'payment-terms/denied/permission',
+          },
+        },
+        {
+          path: 'payment-terms/denied/:type',
+        },
+      ],
+    },
+  ];
+
+  const runGuard = (route: ActivatedRouteSnapshot) =>
+    TestBed.runInInjectionContext(() => businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot));
+
+  const getActiveRoute = async (url: string): Promise<ActivatedRouteSnapshot> => {
+    await router.navigateByUrl(url);
+
+    let activeRoute = router.routerState.snapshot.root;
+    while (activeRoute.firstChild) {
+      activeRoute = activeRoute.firstChild;
+    }
+
+    return activeRoute;
+  };
+
   beforeEach(() => {
-    createUrlTreeMock = vi.fn().mockName('Router.createUrlTree');
     hasBusinessUnitPermissionAccessMock = vi.fn().mockName('PermissionsService.hasBusinessUnitPermissionAccess');
     getLoggedInUserStateMock = vi.fn().mockName('OpalUserService.getLoggedInUserState');
     resolveBusinessUnitIdMock = vi.fn().mockName('BusinessUnitIdResolver.resolveBusinessUnitId');
@@ -43,12 +81,7 @@ describe('businessUnitRoutePermissionsGuard', () => {
 
     TestBed.configureTestingModule({
       providers: [
-        {
-          provide: Router,
-          useValue: {
-            createUrlTree: createUrlTreeMock,
-          },
-        },
+        provideRouter(accountRoutes),
         {
           provide: PermissionsService,
           useValue: {
@@ -69,14 +102,14 @@ describe('businessUnitRoutePermissionsGuard', () => {
         },
       ],
     });
+
+    router = TestBed.inject(Router);
   });
 
   it('should allow access when the route does not require any permissions', async () => {
     const route = createRoute();
 
-    const result = await TestBed.runInInjectionContext(() =>
-      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
-    );
+    const result = await runGuard(route);
 
     expect(result).toBe(true);
     expect(getLoggedInUserStateMock).not.toHaveBeenCalled();
@@ -86,9 +119,7 @@ describe('businessUnitRoutePermissionsGuard', () => {
   it('should allow access when the user has the required permission in the resolved business unit', async () => {
     const route = createRoute([77]);
 
-    const result = await TestBed.runInInjectionContext(() =>
-      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
-    );
+    const result = await runGuard(route);
 
     expect(result).toBe(true);
     expect(getLoggedInUserStateMock).toHaveBeenCalledTimes(1);
@@ -96,48 +127,58 @@ describe('businessUnitRoutePermissionsGuard', () => {
     expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
   });
 
+  it('should allow access when the business unit resolver returns an observable', async () => {
+    resolveBusinessUnitIdMock.mockReturnValue(of(123));
+    const route = createRoute([77]);
+
+    const result = await runGuard(route);
+
+    expect(result).toBe(true);
+    expect(hasBusinessUnitPermissionAccessMock).toHaveBeenCalledWith(77, 123, userState.business_unit_users);
+  });
+
   it('should redirect to the configured access denied path when the user lacks the required permission', async () => {
-    const expectedUrlTree = new UrlTree();
     hasBusinessUnitPermissionAccessMock.mockReturnValue(false);
-    createUrlTreeMock.mockReturnValue(expectedUrlTree);
     const route = createRoute([77], '/custom-denied');
 
-    const result = await TestBed.runInInjectionContext(() =>
-      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
-    );
+    const result = await runGuard(route);
 
-    expect(result).toBe(expectedUrlTree);
-    expect(createUrlTreeMock).toHaveBeenCalledWith(['/custom-denied']);
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
+  });
+
+  it('should redirect to an account-scoped access denied path when the configured path is relative', async () => {
+    hasBusinessUnitPermissionAccessMock.mockReturnValue(false);
+    const route = await getActiveRoute('/fines/account/defendant/12345678/payment-terms/amend');
+
+    const result = await runGuard(route);
+
+    expect(result).toBeInstanceOf(UrlTree);
+    expect(router.serializeUrl(result as UrlTree)).toBe(
+      '/fines/account/defendant/12345678/payment-terms/denied/permission',
+    );
   });
 
   it('should redirect when the resolver cannot determine the business unit', async () => {
-    const expectedUrlTree = new UrlTree();
     resolveBusinessUnitIdMock.mockResolvedValueOnce(null);
-    createUrlTreeMock.mockReturnValue(expectedUrlTree);
     const route = createRoute([77], '/custom-denied');
 
-    const result = await TestBed.runInInjectionContext(() =>
-      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
-    );
+    const result = await runGuard(route);
 
-    expect(result).toBe(expectedUrlTree);
+    expect(result).toBeInstanceOf(UrlTree);
     expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
-    expect(createUrlTreeMock).toHaveBeenCalledWith(['/custom-denied']);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/custom-denied');
   });
 
   it('should redirect when the user has no business unit roles', async () => {
-    const expectedUrlTree = new UrlTree();
     getLoggedInUserStateMock.mockReturnValue(of({ business_unit_users: [] }));
-    createUrlTreeMock.mockReturnValue(expectedUrlTree);
     const route = createRoute([77]);
 
-    const result = await TestBed.runInInjectionContext(() =>
-      businessUnitRoutePermissionsGuard(route, {} as RouterStateSnapshot),
-    );
+    const result = await runGuard(route);
 
-    expect(result).toBe(expectedUrlTree);
+    expect(result).toBeInstanceOf(UrlTree);
     expect(resolveBusinessUnitIdMock).not.toHaveBeenCalled();
     expect(hasBusinessUnitPermissionAccessMock).not.toHaveBeenCalled();
-    expect(createUrlTreeMock).toHaveBeenCalledWith([`/${'access-denied'}`]);
+    expect(router.serializeUrl(result as UrlTree)).toBe('/access-denied');
   });
 });

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.ts
@@ -1,16 +1,38 @@
 import { inject, InjectionToken } from '@angular/core';
-import { type ActivatedRouteSnapshot, type CanActivateFn, type MaybeAsync, Router } from '@angular/router';
+import {
+  type ActivatedRouteSnapshot,
+  type CanActivateFn,
+  createUrlTreeFromSnapshot,
+  type MaybeAsync,
+  Router,
+} from '@angular/router';
 import { firstValueFrom, isObservable } from 'rxjs';
 import { PermissionsService } from '@hmcts/opal-frontend-common/services/permissions-service';
 import { PAGES_ROUTING_PATHS } from '@hmcts/opal-frontend-common/pages/routing/constants';
 import { OpalUserService } from '@hmcts/opal-frontend-common/services/opal-user-service';
 import { BusinessUnitIdResolver } from './interfaces/business-unit-id-resolver.interface';
 
+/**
+ * Injection token used by consuming applications to provide a resolver that can
+ * determine the business unit for the current route context.
+ */
 export const BUSINESS_UNIT_ID_RESOLVER = new InjectionToken<BusinessUnitIdResolver>('BUSINESS_UNIT_ID_RESOLVER');
 
+/**
+ * Resolves values that may be synchronous, promise-based, or observable-based into a promise.
+ *
+ * @param value - The value to resolve.
+ * @returns A promise containing the resolved value.
+ */
 const resolveMaybeAsync = async <T>(value: MaybeAsync<T>): Promise<T> =>
   isObservable(value) ? firstValueFrom(value) : Promise.resolve(value);
 
+/**
+ * Reads and normalizes the permission ids declared on route data.
+ *
+ * @param route - The route whose permission metadata should be inspected.
+ * @returns A filtered array of numeric permission ids.
+ */
 const getRoutePermissionIds = (route: ActivatedRouteSnapshot): number[] => {
   const routePermissionIds = route.data?.['routePermissionId'];
 
@@ -25,8 +47,37 @@ const getRoutePermissionIds = (route: ActivatedRouteSnapshot): number[] => {
   return [];
 };
 
-const toAccessDeniedUrlTree = (router: Router, accessDeniedPath: string) => router.createUrlTree([accessDeniedPath]);
+/**
+ * Creates the access denied redirect for permission failures.
+ *
+ * Absolute paths are resolved from the app root. Relative paths are resolved
+ * from the guarded route's parent so account-flow denied pages stay under the
+ * current account route.
+ *
+ * @param route - The route being protected by the guard.
+ * @param router - The router used to create the redirect URL tree.
+ * @param accessDeniedPath - The configured access denied path.
+ * @returns A URL tree pointing to the denied route.
+ */
+const toAccessDeniedUrlTree = (route: ActivatedRouteSnapshot, router: Router, accessDeniedPath: string) => {
+  if (accessDeniedPath.startsWith('/')) {
+    return router.createUrlTree([accessDeniedPath]);
+  }
 
+  return createUrlTreeFromSnapshot(route.parent ?? route, [accessDeniedPath]);
+};
+
+/**
+ * Guard that checks route permissions against the business unit resolved for the
+ * current route instead of against the user's global permission set.
+ *
+ * If the route does not declare any permission ids, the guard allows access.
+ * Otherwise it loads the logged-in user state, resolves the route business unit,
+ * and confirms that at least one declared permission exists within that business unit.
+ *
+ * @param route - The route being activated.
+ * @returns `true` when access is allowed, otherwise a redirect to access denied.
+ */
 export const businessUnitRoutePermissionsGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
   const routePermissionIds = getRoutePermissionIds(route);
 
@@ -45,21 +96,21 @@ export const businessUnitRoutePermissionsGuard: CanActivateFn = async (route: Ac
     const businessUnitUsers = userState?.business_unit_users ?? [];
 
     if (!businessUnitUsers.length) {
-      return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+      return toAccessDeniedUrlTree(route, router, `${accessDeniedPath}`);
     }
 
     const businessUnitId = await resolveMaybeAsync(businessUnitResolver.resolveBusinessUnitId(route));
 
     if (typeof businessUnitId !== 'number' || !Number.isFinite(businessUnitId) || businessUnitId <= 0) {
-      return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+      return toAccessDeniedUrlTree(route, router, `${accessDeniedPath}`);
     }
 
     const hasAccess = routePermissionIds.some((permissionId) =>
       permissionService.hasBusinessUnitPermissionAccess(permissionId, businessUnitId, businessUnitUsers),
     );
 
-    return hasAccess ? true : toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+    return hasAccess ? true : toAccessDeniedUrlTree(route, router, `${accessDeniedPath}`);
   } catch {
-    return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+    return toAccessDeniedUrlTree(route, router, `${accessDeniedPath}`);
   }
 };

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/business-unit-route-permissions.guard.ts
@@ -1,0 +1,65 @@
+import { inject, InjectionToken } from '@angular/core';
+import { type ActivatedRouteSnapshot, type CanActivateFn, type MaybeAsync, Router } from '@angular/router';
+import { firstValueFrom, isObservable } from 'rxjs';
+import { PermissionsService } from '@hmcts/opal-frontend-common/services/permissions-service';
+import { PAGES_ROUTING_PATHS } from '@hmcts/opal-frontend-common/pages/routing/constants';
+import { OpalUserService } from '@hmcts/opal-frontend-common/services/opal-user-service';
+import { BusinessUnitIdResolver } from './interfaces/business-unit-id-resolver.interface';
+
+export const BUSINESS_UNIT_ID_RESOLVER = new InjectionToken<BusinessUnitIdResolver>('BUSINESS_UNIT_ID_RESOLVER');
+
+const resolveMaybeAsync = async <T>(value: MaybeAsync<T>): Promise<T> =>
+  isObservable(value) ? firstValueFrom(value) : Promise.resolve(value);
+
+const getRoutePermissionIds = (route: ActivatedRouteSnapshot): number[] => {
+  const routePermissionIds = route.data?.['routePermissionId'];
+
+  if (Array.isArray(routePermissionIds)) {
+    return routePermissionIds.filter((permissionId): permissionId is number => typeof permissionId === 'number');
+  }
+
+  if (typeof routePermissionIds === 'number') {
+    return [routePermissionIds];
+  }
+
+  return [];
+};
+
+const toAccessDeniedUrlTree = (router: Router, accessDeniedPath: string) => router.createUrlTree([accessDeniedPath]);
+
+export const businessUnitRoutePermissionsGuard: CanActivateFn = async (route: ActivatedRouteSnapshot) => {
+  const routePermissionIds = getRoutePermissionIds(route);
+
+  if (!routePermissionIds.length) {
+    return true;
+  }
+
+  const permissionService = inject(PermissionsService);
+  const opalUserService = inject(OpalUserService);
+  const businessUnitResolver = inject(BUSINESS_UNIT_ID_RESOLVER);
+  const router = inject(Router);
+  const accessDeniedPath = route.data?.['accessDeniedPath'] ?? `/${PAGES_ROUTING_PATHS.children.accessDenied}`;
+
+  try {
+    const userState = await firstValueFrom(opalUserService.getLoggedInUserState());
+    const businessUnitUsers = userState?.business_unit_users ?? [];
+
+    if (!businessUnitUsers.length) {
+      return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+    }
+
+    const businessUnitId = await resolveMaybeAsync(businessUnitResolver.resolveBusinessUnitId(route));
+
+    if (typeof businessUnitId !== 'number' || !Number.isFinite(businessUnitId) || businessUnitId <= 0) {
+      return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+    }
+
+    const hasAccess = routePermissionIds.some((permissionId) =>
+      permissionService.hasBusinessUnitPermissionAccess(permissionId, businessUnitId, businessUnitUsers),
+    );
+
+    return hasAccess ? true : toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+  } catch {
+    return toAccessDeniedUrlTree(router, `${accessDeniedPath}`);
+  }
+};

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/interfaces/business-unit-id-resolver.interface.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/interfaces/business-unit-id-resolver.interface.ts
@@ -1,5 +1,16 @@
 import { type ActivatedRouteSnapshot, type MaybeAsync } from '@angular/router';
 
+/**
+ * Contract implemented by consuming apps to resolve the business unit for the active route.
+ */
 export interface BusinessUnitIdResolver {
+  /**
+   * Resolves the business unit id that should be used for route-level permission checks.
+   *
+   * Return `null` when the business unit cannot be determined for the route.
+   *
+   * @param route - The route being protected by the business-unit permission guard.
+   * @returns The business unit id, or `null` when no valid business unit is available.
+   */
   resolveBusinessUnitId(route: ActivatedRouteSnapshot): MaybeAsync<number | null>;
 }

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/interfaces/business-unit-id-resolver.interface.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/interfaces/business-unit-id-resolver.interface.ts
@@ -1,0 +1,5 @@
+import { type ActivatedRouteSnapshot, type MaybeAsync } from '@angular/router';
+
+export interface BusinessUnitIdResolver {
+  resolveBusinessUnitId(route: ActivatedRouteSnapshot): MaybeAsync<number | null>;
+}

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/ng-package.json
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/ng-package.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+    "lib": {
+      "entryFile": "public-api.ts"
+    }
+  }

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/package.json
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/package.json
@@ -1,0 +1,5 @@
+{
+    "sideEffects": false,
+    "module": "../../../dist/opal-frontend-common/fesm2022/hmcts-opal-frontend-common-guards-business-unit-route-permissions.mjs",
+    "typings": "../../../dist/opal-frontend-common/guards/business-unit-route-permissions/index.d.ts"
+  }

--- a/projects/opal-frontend-common/guards/business-unit-route-permissions/public-api.ts
+++ b/projects/opal-frontend-common/guards/business-unit-route-permissions/public-api.ts
@@ -1,0 +1,2 @@
+export * from './business-unit-route-permissions.guard';
+export * from './interfaces/business-unit-id-resolver.interface';

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.82",
+  "version": "0.0.83",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -373,6 +373,9 @@
     "./guards/account": {
       "import": "./fesm2022/hmcts-opal-frontend-common-guards-account.mjs"
     },
+    "./guards/business-unit-route-permissions": {
+      "import": "./fesm2022/hmcts-opal-frontend-common-guards-business-unit-route-permissions.mjs"
+    },
     "./guards/can-deactivate": {
       "import": "./fesm2022/hmcts-opal-frontend-common-guards-can-deactivate.mjs"
     },

--- a/projects/opal-frontend-common/package.json
+++ b/projects/opal-frontend-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/opal-frontend-common",
-  "version": "0.0.83",
+  "version": "0.0.84",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -327,6 +327,9 @@
       "@hmcts/opal-frontend-common/constants": ["./dist/opal-frontend-common/constants"],
       "@hmcts/opal-frontend-common/guards/account": ["./dist/opal-frontend-common/guards/account"],
       "@hmcts/opal-frontend-common/guards/auth": ["./dist/opal-frontend-common/guards/auth"],
+      "@hmcts/opal-frontend-common/guards/business-unit-route-permissions": [
+        "./dist/opal-frontend-common/guards/business-unit-route-permissions"
+      ],
       "@hmcts/opal-frontend-common/guards/can-deactivate": ["./dist/opal-frontend-common/guards/can-deactivate"],
       "@hmcts/opal-frontend-common/guards/can-deactivate/interfaces": [
         "./dist/opal-frontend-common/guards/can-deactivate/interfaces"


### PR DESCRIPTION

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PO-5773](https://tools.hmcts.net/jira/browse/PO-5773)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

Some account maintenance routes rely on UI-level business-unit permission checks before navigating, but the route guards currently only check global permission IDs. This means the route layer cannot consistently enforce "user has permission X in the account's business unit" across direct navigation scenarios. We cannot reset FinesAccountStore on these journeys because amend/change/add pages depend on it.

Problem

routePermissionsGuard is generic and only checks whether the user has a permission anywhere. It does not know which business unit applies to the route. For account journeys, the relevant BU comes from account state or account heading data, not from static route configuration.


Proposed Approach

Add a reusable business-unit permission guard pattern.

In opal-frontend-common-ui-lib, provide a generic guard.

## Common library dependency note

This PO-5773 change spans two repositories:

- opal-frontend
- opal-frontend-common-ui-lib

The frontend branch depends on new common-library behaviour introduced in the matching `opal-frontend-common-ui-lib` PO-5773 branch. Specifically, the common library adds/updates the BU-aware route permission guard so account-scoped denied routes are resolved relative to the current account route.

During local testing, the frontend was run against a locally packed common-library tarball. That local tarball dependency has **not** been committed, because a `file:` dependency would only work on a developer machine and would break CI/QA.

At the moment, the committed `opal-frontend` branch still points at the currently published common library version:

"@hmcts/opal-frontend-common": "^0.0.82"

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

Unit tests added
Manual browser testing

This the test plan I used to regression test all the routes that now use this generic guard:
[PO-5773_ROUTE_BROWSER_TEST_PLAN.xls](https://github.com/user-attachments/files/28962057/PO-5773_ROUTE_BROWSER_TEST_PLAN.xls)


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
